### PR TITLE
Wrap tooltip provider

### DIFF
--- a/dev/Query.tsx
+++ b/dev/Query.tsx
@@ -9,10 +9,15 @@ import * as React from 'react';
 import * as QB from '@malloydata/malloy-query-builder';
 import {useEffect, useState} from 'react';
 import {createRoot} from 'react-dom/client';
-import {MalloyPreview, QueryActionBar, QueryEditor, RawPreview} from '../src';
+import {
+  MalloyExplorerProvider,
+  MalloyPreview,
+  QueryActionBar,
+  QueryEditor,
+  RawPreview,
+} from '../src';
 import * as Malloy from '@malloydata/malloy-interfaces';
 import {modelInfo, queries as exampleQueries} from './example_model';
-import {TooltipProvider} from '@radix-ui/react-tooltip';
 const source = modelInfo.entries.at(-1) as Malloy.SourceInfo;
 
 const queries = [undefined, ...exampleQueries];
@@ -31,7 +36,7 @@ const App = () => {
   }, [queryIdx]);
 
   return (
-    <TooltipProvider>
+    <MalloyExplorerProvider>
       <div style={{width: 500}}>
         Query: {queryIdx}{' '}
         <button onClick={() => setQueryIdx((queryIdx + 1) % queries.length)}>
@@ -60,7 +65,7 @@ const App = () => {
           <div>No query</div>
         )}
       </div>
-    </TooltipProvider>
+    </MalloyExplorerProvider>
   );
 };
 

--- a/dev/Source.tsx
+++ b/dev/Source.tsx
@@ -9,21 +9,20 @@ import * as React from 'react';
 import {createRoot} from 'react-dom/client';
 import * as Malloy from '@malloydata/malloy-interfaces';
 import {modelInfo} from './example_model';
-import {TooltipProvider} from '@radix-ui/react-tooltip';
-import {SourcePanel} from '../src';
+import {MalloyExplorerProvider, SourcePanel} from '../src';
 import ShowcaseButtons from './components/Buttons';
 const source = modelInfo.entries.at(-1) as Malloy.SourceInfo;
 
 const App = () => {
   return (
-    <TooltipProvider>
+    <MalloyExplorerProvider>
       <div style={{display: 'flex'}}>
         <SourcePanel source={source} />
         <div style={{padding: '8px'}}>
           <ShowcaseButtons />
         </div>
       </div>
-    </TooltipProvider>
+    </MalloyExplorerProvider>
   );
 };
 

--- a/src/components/MalloyExplorerProvider.tsx
+++ b/src/components/MalloyExplorerProvider.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from 'react';
+import {ReactNode} from 'react';
+import {TooltipProvider} from '@radix-ui/react-tooltip';
+
+export interface MalloyExplorerProviderProps {
+  children: ReactNode | ReactNode[];
+}
+
+export function MalloyExplorerProvider({
+  children,
+}: MalloyExplorerProviderProps) {
+  return <TooltipProvider>{children}</TooltipProvider>;
+}

--- a/src/components/QueryPanel/QueryEditor.tsx
+++ b/src/components/QueryPanel/QueryEditor.tsx
@@ -36,8 +36,6 @@ const queryExplorerStyles = stylex.create({
  * The Query Viewing and Editing panel. Takes a `SourceInfo` object
  * and an optional `Query` object.
  *
- * Wrap in a [QueryEditorContext] with a `setQuery` method to support editing.
- *
  * @param source The source object to be used for query building.
  * @param query A query to be edited. Omit for a new query.
  * @returns

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+export {MalloyExplorerProvider} from './components/MalloyExplorerProvider';
 export {MalloyPreview} from './components/MalloyPreview';
 export {QueryActionBar, QueryEditor} from './components/QueryPanel';
 export {RawPreview} from './components/RawPreview';


### PR DESCRIPTION
Export TooltipProvider in our own wrapper so we can avoid having to reference radix outside of our bundle.