### PR TITLE
Update Query panel to use Collapsible Panels for each section

### DIFF
--- a/src/components/QueryPanel/Parameters.tsx
+++ b/src/components/QueryPanel/Parameters.tsx
@@ -11,12 +11,12 @@ import {
   ASTArrowQueryDefinition,
   ASTQuery,
 } from '@malloydata/malloy-query-builder';
-import stylex from '@stylexjs/stylex';
-import {styles} from '../styles';
 import {LiteralValueEditor} from './LiteralValueEditor';
 import {QueryEditorContext} from '../../contexts/QueryEditorContext';
 import {Token, TokenGroup} from '../primitives';
 import {atomicTypeToIcon} from '../utils/icon';
+import CollapsiblePanel from '../primitives/CollapsiblePanel';
+import stylex from '@stylexjs/stylex';
 
 /**
  * Source
@@ -40,28 +40,35 @@ export function Parameters({rootQuery}: ParametersProps) {
     }
 
     return (
-      <div {...stylex.props(styles.queryCard)}>
-        <div {...stylex.props(styles.title)}>Source parameters</div>
-        {sourceParameters.map((parameter, key) => (
-          <TokenGroup key={key}>
-            <Token
-              icon={atomicTypeToIcon(parameter.type.kind)}
-              label={parameter.name}
-            />
-            <LiteralValueEditor
-              value={
-                source.tryGetParameter(parameter.name)?.parameter.value ??
-                parameter.default_value
-              }
-              setValue={value => {
-                source.setParameter(parameter.name, value);
-                setQuery?.(rootQuery.build());
-              }}
-            />
-          </TokenGroup>
-        ))}
-      </div>
+      <CollapsiblePanel title="Source parameters">
+        <div {...stylex.props(styles.parameters)}>
+          {sourceParameters.map((parameter, key) => (
+            <TokenGroup key={key}>
+              <Token
+                icon={atomicTypeToIcon(parameter.type.kind)}
+                label={parameter.name}
+              />
+              <LiteralValueEditor
+                value={
+                  source.tryGetParameter(parameter.name)?.parameter.value ??
+                  parameter.default_value
+                }
+                setValue={value => {
+                  source.setParameter(parameter.name, value);
+                  setQuery?.(rootQuery.build());
+                }}
+              />
+            </TokenGroup>
+          ))}
+        </div>
+      </CollapsiblePanel>
     );
   }
   return null;
 }
+
+const styles = stylex.create({
+  parameters: {
+    marginLeft: '16px',
+  },
+});

--- a/src/components/QueryPanel/Query.tsx
+++ b/src/components/QueryPanel/Query.tsx
@@ -6,11 +6,13 @@
  */
 
 import * as React from 'react';
+import * as Malloy from '@malloydata/malloy-interfaces';
 import {
   ASTArrowQueryDefinition,
   ASTQuery,
 } from '@malloydata/malloy-query-builder';
 import stylex from '@stylexjs/stylex';
+
 import {styles} from '../styles';
 import {ViewMenu} from './ViewMenu';
 import {ViewDefinition} from './ViewDefinition';
@@ -21,19 +23,20 @@ import Icon from '../primitives/Icon';
 export interface QueryProps {
   rootQuery: ASTQuery;
   query: ASTQuery;
-  setQuery?: (query: Malloy.Query) => void;
+  setQuery?: (query: Malloy.Query | undefined) => void;
 }
 
 export function Query({rootQuery, query, setQuery}: QueryProps) {
-  const menuItems = [
-    {
+  const menuItems = [];
+  if (setQuery) {
+    menuItems.push({
       icon: <Icon name="clear" />,
       label: 'Clear query',
       onClick: () => {
-        setQuery(undefined);
+        setQuery?.(undefined);
       },
-    },
-  ];
+    });
+  }
 
   return (
     <CollapsiblePanel title="Main query" menuItems={menuItems}>

--- a/src/components/QueryPanel/Query.tsx
+++ b/src/components/QueryPanel/Query.tsx
@@ -15,6 +15,7 @@ import {styles} from '../styles';
 import {ViewMenu} from './ViewMenu';
 import {ViewDefinition} from './ViewDefinition';
 import {Visualization} from './Visualization';
+import CollapsiblePanel from '../primitives/CollapsiblePanel';
 
 export interface QueryProps {
   rootQuery: ASTQuery;
@@ -23,10 +24,7 @@ export interface QueryProps {
 
 export function Query({rootQuery, query}: QueryProps) {
   return (
-    <div {...stylex.props(styles.queryCard)}>
-      <div {...stylex.props(styles.queryHeader)}>
-        <div {...stylex.props(styles.title)}>Main query</div>
-      </div>
+    <CollapsiblePanel title="Main query">
       {query.definition instanceof ASTArrowQueryDefinition ? (
         <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
           {!query.isEmpty() && (
@@ -47,7 +45,7 @@ export function Query({rootQuery, query}: QueryProps) {
           <ViewMenu rootQuery={rootQuery} view={query} />
         </div>
       )}
-    </div>
+    </CollapsiblePanel>
   );
 }
 

--- a/src/components/QueryPanel/Query.tsx
+++ b/src/components/QueryPanel/Query.tsx
@@ -16,15 +16,27 @@ import {ViewMenu} from './ViewMenu';
 import {ViewDefinition} from './ViewDefinition';
 import {Visualization} from './Visualization';
 import CollapsiblePanel from '../primitives/CollapsiblePanel';
+import Icon from '../primitives/Icon';
 
 export interface QueryProps {
   rootQuery: ASTQuery;
   query: ASTQuery;
+  setQuery?: (query: Malloy.Query) => void;
 }
 
-export function Query({rootQuery, query}: QueryProps) {
+export function Query({rootQuery, query, setQuery}: QueryProps) {
+  const menuItems = [
+    {
+      icon: <Icon name="clear" />,
+      label: 'Clear query',
+      onClick: () => {
+        setQuery(undefined);
+      },
+    },
+  ];
+
   return (
-    <CollapsiblePanel title="Main query">
+    <CollapsiblePanel title="Main query" menuItems={menuItems}>
       {query.definition instanceof ASTArrowQueryDefinition ? (
         <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
           {!query.isEmpty() && (

--- a/src/components/QueryPanel/QueryEditor.tsx
+++ b/src/components/QueryPanel/QueryEditor.tsx
@@ -18,7 +18,7 @@ import {QueryEditorContext} from '../../contexts/QueryEditorContext';
 export interface QueryEditorProps {
   source: Malloy.SourceInfo;
   query?: Malloy.Query;
-  setQuery?: (query: Malloy.Query) => void;
+  setQuery?: (query: Malloy.Query | undefined) => void;
 }
 
 const queryExplorerStyles = stylex.create({

--- a/src/components/QueryPanel/QueryEditor.tsx
+++ b/src/components/QueryPanel/QueryEditor.tsx
@@ -52,7 +52,7 @@ export function QueryEditor({source, query, setQuery}: QueryEditorProps) {
       <div {...stylex.props(queryExplorerStyles.main)}>
         <Source rootQuery={rootQuery} />
         <Parameters rootQuery={rootQuery} />
-        <Query rootQuery={rootQuery} query={rootQuery} />
+        <Query rootQuery={rootQuery} query={rootQuery} setQuery={setQuery} />
       </div>
     </QueryEditorContext.Provider>
   );

--- a/src/components/QueryPanel/operations/NestOperation.tsx
+++ b/src/components/QueryPanel/operations/NestOperation.tsx
@@ -58,15 +58,11 @@ export function NestOperations({rootQuery, nests}: NestOperationsProps) {
 
           return (
             <div key={key} {...stylex.props(viewStyles.indent)}>
-              <CollapsiblePanel title={'Nested query'} icon="nest">
-                <TokenGroup style={localStyles.header}>
-                  <Token
-                    icon="nest"
-                    label={nest.name}
-                    style={localStyles.left}
-                  />
-                  <Menu trigger={<Token icon="meatballs" />} items={actions} />
-                </TokenGroup>
+              <CollapsiblePanel
+                title={'Nested query'}
+                icon="nest"
+                menuItems={actions}
+              >
                 <View rootQuery={rootQuery} view={nest.view} />
               </CollapsiblePanel>
             </div>
@@ -76,14 +72,3 @@ export function NestOperations({rootQuery, nests}: NestOperationsProps) {
     </div>
   );
 }
-
-const localStyles = stylex.create({
-  header: {
-    width: '100%',
-    paddingBottom: 8,
-  },
-  left: {
-    flexGrow: 1,
-    justifyContent: 'start',
-  },
-});

--- a/src/components/QueryPanel/operations/NestOperation.tsx
+++ b/src/components/QueryPanel/operations/NestOperation.tsx
@@ -14,8 +14,7 @@ import {
 import stylex from '@stylexjs/stylex';
 import {styles} from '../../styles';
 import {View} from '../View';
-import {Icon, Token, TokenGroup} from '../../primitives';
-import {Menu} from '../../Menu';
+import {Icon} from '../../primitives';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import {useContext} from 'react';
 import CollapsiblePanel from '../../primitives/CollapsiblePanel';

--- a/src/components/QueryPanel/operations/NestOperation.tsx
+++ b/src/components/QueryPanel/operations/NestOperation.tsx
@@ -18,6 +18,7 @@ import {Icon, Token, TokenGroup} from '../../primitives';
 import {Menu} from '../../Menu';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import {useContext} from 'react';
+import CollapsiblePanel from '../../primitives/CollapsiblePanel';
 
 export interface NestOperationsProps {
   rootQuery: ASTQuery;
@@ -57,7 +58,7 @@ export function NestOperations({rootQuery, nests}: NestOperationsProps) {
 
           return (
             <div key={key} {...stylex.props(viewStyles.indent)}>
-              <div {...stylex.props(styles.queryCard)}>
+              <CollapsiblePanel title={'Nested query'} icon="nest">
                 <TokenGroup style={localStyles.header}>
                   <Token
                     icon="nest"
@@ -67,7 +68,7 @@ export function NestOperations({rootQuery, nests}: NestOperationsProps) {
                   <Menu trigger={<Token icon="meatballs" />} items={actions} />
                 </TokenGroup>
                 <View rootQuery={rootQuery} view={nest.view} />
-              </div>
+              </CollapsiblePanel>
             </div>
           );
         })}

--- a/src/components/primitives/Button.tsx
+++ b/src/components/primitives/Button.tsx
@@ -37,7 +37,7 @@ interface ButtonProps {
   label?: string;
 
   /**
-   * The icon to be shown either to the left of the label or centered (if label is not provided.
+   * The icon to be shown either to the left of the label or centered (if label is not provided).
    */
   icon?: IconType;
 

--- a/src/components/primitives/Button.tsx
+++ b/src/components/primitives/Button.tsx
@@ -11,7 +11,8 @@ import {IconType} from './utils/icon';
 import Icon from './Icon';
 import {iconColors, textColors} from './colors.stylex';
 import {iconVars, labelVars} from './button.stylex';
-import {fontStyles} from './styles';
+import {fontStyles, tooltipStyles} from './styles';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@radix-ui/react-tooltip';
 
 const DEFAULT_VARIANT = 'default';
 const DEFAULT_SIZE = 'default';
@@ -37,6 +38,11 @@ interface ButtonProps {
   label?: string;
 
   /**
+   * The tooltip to show when hovering over the button. All buttons without a label need a tooltip.
+   */
+  tooltip?: string;
+
+  /**
    * The icon to be shown either to the left of the label or centered (if label is not provided).
    */
   icon?: IconType;
@@ -59,34 +65,48 @@ export default function Button({
   size = DEFAULT_SIZE,
   icon,
   label,
+  tooltip,
   onClick,
   isDisabled = false,
 }: ButtonProps) {
   return (
-    <button
-      {...stylex.props(styles.main, colorVariants[variant], sizeVariants[size])}
-      onClick={e => {
-        e.preventDefault();
-        onClick(e);
-      }}
-      type="button"
-      disabled={isDisabled}
-    >
-      <div {...stylex.props(styles.content)}>
-        {icon && <Icon name={icon} style={styles.icon} />}
-        {label && (
-          <div
-            {...stylex.props(
-              variant === 'primary' ? fontStyles.emphasized : fontStyles.body,
-              styles.label
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <button
+          {...stylex.props(
+            styles.main,
+            colorVariants[variant],
+            sizeVariants[size]
+          )}
+          onClick={e => {
+            e.preventDefault();
+            onClick(e);
+          }}
+          type="button"
+          disabled={isDisabled}
+        >
+          <div {...stylex.props(styles.content)}>
+            {icon && <Icon name={icon} style={styles.icon} />}
+            {label && (
+              <div
+                {...stylex.props(
+                  variant === 'primary'
+                    ? fontStyles.emphasized
+                    : fontStyles.body,
+                  styles.label
+                )}
+              >
+                {label}
+              </div>
             )}
-          >
-            {label}
           </div>
-        )}
-      </div>
-      {isDisabled && <div {...stylex.props(styles.disabledOverlay)}></div>}
-    </button>
+          {isDisabled && <div {...stylex.props(styles.disabledOverlay)}></div>}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div {...stylex.props(tooltipStyles.default)}>{tooltip}</div>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/components/primitives/CollapsiblePanel.tsx
+++ b/src/components/primitives/CollapsiblePanel.tsx
@@ -11,6 +11,7 @@ import {useState} from 'react';
 import Button from './Button';
 import {IconType} from './utils/icon';
 import Icon from './Icon';
+import {Menu, MenuItem} from '../Menu';
 
 interface CollapsiblePanelProps {
   title: string;
@@ -18,6 +19,9 @@ interface CollapsiblePanelProps {
 
   // The icon to be shown to the left of the title.
   icon?: IconType;
+
+  // If provided, a Kebab menu will be rendered with these items in the dropdown.
+  menuItems?: MenuItem[];
 }
 
 /*
@@ -27,6 +31,7 @@ export default function CollapsiblePanel({
   title,
   children,
   icon,
+  menuItems,
 }: CollapsiblePanelProps) {
   const [isExpanded, setIsExpanded] = useState(true);
 
@@ -35,7 +40,15 @@ export default function CollapsiblePanel({
       <div {...stylex.props(styles.topBar)}>
         {icon && <Icon name={icon} style={styles.icon} />}
         <div {...stylex.props(styles.title)}>{title}</div>
-        <div>
+        <div {...stylex.props(styles.topBarRightSection)}>
+          {menuItems && (
+            <Menu
+              trigger={
+                <Button variant="flat" size="compact" icon="meatballs" />
+              }
+              items={menuItems}
+            />
+          )}
           <Button
             variant="flat"
             size="compact"
@@ -61,6 +74,9 @@ const styles = stylex.create({
     padding: '4px',
     gap: '8px',
     alignItems: 'center',
+  },
+  topBarRightSection: {
+    display: 'flex',
   },
   title: {
     whiteSpace: 'nowrap',

--- a/src/components/primitives/CollapsiblePanel.tsx
+++ b/src/components/primitives/CollapsiblePanel.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from 'react';
+import stylex from '@stylexjs/stylex';
+import {useState} from 'react';
+import Button from './Button';
+
+interface CollapsiblePanelProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+/*
+ * Provides a panel component which can be collapsed and expanded.
+ */
+export default function CollapsiblePanel({
+  title,
+  children,
+}: CollapsiblePanelProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  return (
+    <div {...stylex.props(styles.container)}>
+      <div {...stylex.props(styles.topBar)}>
+        <div {...stylex.props(styles.title)}>{title}</div>
+        <div>
+          <Button
+            variant="flat"
+            size="compact"
+            onClick={() => setIsExpanded(!isExpanded)}
+            icon={isExpanded ? 'chevronDown' : 'chevronRight'}
+          />
+        </div>
+      </div>
+      {isExpanded && <div {...stylex.props(styles.content)}>{children}</div>}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    border: '1px solid #CCD3DB',
+    borderRadius: 5,
+    padding: 0,
+  },
+  topBar: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '4px',
+    alignItems: 'center',
+  },
+  title: {
+    whiteSpace: 'nowrap',
+    padding: '0 4px',
+    margin: 0,
+  },
+  content: {
+    padding: '0 8px 8px 8px',
+  },
+});

--- a/src/components/primitives/CollapsiblePanel.tsx
+++ b/src/components/primitives/CollapsiblePanel.tsx
@@ -9,10 +9,15 @@ import * as React from 'react';
 import stylex from '@stylexjs/stylex';
 import {useState} from 'react';
 import Button from './Button';
+import {IconType} from './utils/icon';
+import Icon from './Icon';
 
 interface CollapsiblePanelProps {
   title: string;
   children: React.ReactNode;
+
+  // The icon to be shown to the left of the title.
+  icon?: IconType;
 }
 
 /*
@@ -21,12 +26,14 @@ interface CollapsiblePanelProps {
 export default function CollapsiblePanel({
   title,
   children,
+  icon,
 }: CollapsiblePanelProps) {
   const [isExpanded, setIsExpanded] = useState(true);
 
   return (
     <div {...stylex.props(styles.container)}>
       <div {...stylex.props(styles.topBar)}>
+        {icon && <Icon name={icon} style={styles.icon} />}
         <div {...stylex.props(styles.title)}>{title}</div>
         <div>
           <Button
@@ -52,13 +59,16 @@ const styles = stylex.create({
     display: 'flex',
     justifyContent: 'space-between',
     padding: '4px',
+    gap: '8px',
     alignItems: 'center',
   },
   title: {
     whiteSpace: 'nowrap',
     padding: '0 4px',
     margin: 0,
+    flexGrow: 1,
   },
+  icon: {},
   content: {
     padding: '0 8px 8px 8px',
   },

--- a/src/components/primitives/CollapsiblePanel.tsx
+++ b/src/components/primitives/CollapsiblePanel.tsx
@@ -48,6 +48,7 @@ export default function CollapsiblePanel({
                   variant="flat"
                   size="compact"
                   icon="meatballs"
+                  tooltip="More actions..."
                   onClick={() => {}}
                 />
               }
@@ -59,6 +60,7 @@ export default function CollapsiblePanel({
             size="compact"
             onClick={() => setIsExpanded(!isExpanded)}
             icon={isExpanded ? 'chevronDown' : 'chevronRight'}
+            tooltip={isExpanded ? 'Collapse' : 'Expand'}
           />
         </div>
       </div>

--- a/src/components/primitives/CollapsiblePanel.tsx
+++ b/src/components/primitives/CollapsiblePanel.tsx
@@ -44,7 +44,12 @@ export default function CollapsiblePanel({
           {menuItems && (
             <Menu
               trigger={
-                <Button variant="flat" size="compact" icon="meatballs" />
+                <Button
+                  variant="flat"
+                  size="compact"
+                  icon="meatballs"
+                  onClick={() => {}}
+                />
               }
               items={menuItems}
             />

--- a/src/components/primitives/styles.ts
+++ b/src/components/primitives/styles.ts
@@ -7,6 +7,16 @@
 
 import stylex from '@stylexjs/stylex';
 
+export const tooltipStyles = stylex.create({
+  default: {
+    padding: '4px 8px',
+    borderRadius: '6px',
+    color: 'rgba(221, 226, 232, 1)',
+    backgroundColor: 'rgba(50, 52, 54, 1)',
+    maxWidth: '360px',
+  },
+});
+
 export const fontStyles = stylex.create({
   largeEmphasized: {
     fontFamily: 'SF Pro Text, -apple-system, system-ui, sans-serif',

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -21,9 +21,7 @@ export const styles = stylex.create({
     whiteSpace: 'nowrap',
     gap: 8,
   },
-
   label: {},
-
   heading: {
     display: 'flex',
     flexDirection: 'column',
@@ -46,10 +44,6 @@ export const styles = stylex.create({
     flexDirection: 'row',
     width: 'calc(100% - 40)',
     padding: 12,
-  },
-  title: {
-    whiteSpace: 'nowrap',
-    padding: '5px 0',
   },
   tokenContainer: {
     display: 'flex',

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -21,7 +21,9 @@ export const styles = stylex.create({
     whiteSpace: 'nowrap',
     gap: 8,
   },
+
   label: {},
+
   heading: {
     display: 'flex',
     flexDirection: 'column',
@@ -44,6 +46,10 @@ export const styles = stylex.create({
     flexDirection: 'row',
     width: 'calc(100% - 40)',
     padding: 12,
+  },
+  title: {
+    whiteSpace: 'nowrap',
+    padding: '5px 0',
   },
   tokenContainer: {
     display: 'flex',


### PR DESCRIPTION
Following the [design mocks](https://www.figma.com/design/5k0OF2dysA5MyBwW9aEJGv/%E2%93%82%EF%B8%8F-Malloy-MVP?node-id=1119-54233&m=dev), update the Query Panel to include collapsible subpanels. In some cases, moves interaction such as clearing the query up into the 'more actions' menu of the bar.

<img width="540" alt="image" src="https://github.com/user-attachments/assets/d1cbfb05-a2eb-4eeb-b01b-df1fe6cb153f" />

<img width="535" alt="image" src="https://github.com/user-attachments/assets/ee44a3f2-ddd4-4fa3-82a0-f579f16ca3f1" />

