### PR TITLE
Keep the token button inside the token

### DIFF
--- a/src/components/primitives/tokens/styles.ts
+++ b/src/components/primitives/tokens/styles.ts
@@ -18,6 +18,7 @@ export const tokenStyles = stylex.create({
       default: 'rgba(230, 235, 239, 1)',
       ':hover': 'rgba(221, 226, 232, 1)',
     },
+    position: 'relative',
   },
   icon: {
     color: iconVars.color,


### PR DESCRIPTION
It looks like the `position: relative` got dropped from the styles when it moved out of the Token file, causing the absolutely-positioned child to fill the entire page instead of the component ony.