### PR TITLE
Add build/link commands for working with local Malloy packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ npm run dev
 ```
 
 - Open http://localhost:5173/
+
+## Running against a local version of Malloy
+
+1. Run `npm run malloy-build-and-link` once and whenever you need to pull in changes
+2. If you need to pull in changes of `@malloydata/malloy-render`, then navigate to the `malloy` direcory and build it using `npm run build` first.
+3. If you make changes to Malloy that are required by the explorer, then merge those into main, and that will trigger an automatic developer release of Malloy.
+4. Once that release completes, run `npm run malloy-update` to update dependencies to that release. This will break the link to your local version of Malloy, so if you want to resume local development, re-run `npm run malloy-link`
+5. To manually unlink without updating, you may run `npm run malloy-unlink`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "lint": "tsc --noEmit && eslint .",
     "malloy-update-next": "npm install  --no-fund --no-audit --save-exact $(./scripts/malloy-packages.ts next)",
     "malloy-update": "npm install  --no-fund --no-audit --save-exact $(./scripts/malloy-packages.ts latest)",
+    "malloy-link": "npm --no-fund --no-audit link $(./scripts/malloy-packages.ts)",
+    "malloy-unlink": "npm --no-fund --no-save --no-audit unlink $(./scripts/malloy-packages.ts) && npm --no-fund --no-audit install --force",
+    "malloy-build-and-link": "cd ../malloy && npm run -ws build --workspace=@malloydata/malloy-query-builder --workspace=@malloydata/malloy-filter --workspace=@malloydata/malloy-interfaces --workspace=@malloydata/malloy-tag &&  && npm link -ws",
     "test": "jest src"
   },
   "bin": {


### PR DESCRIPTION
Adds npm commands:

* `npm run malloy-build-and-link` for a single-shot build and link for most packages (except `malloy-render` because th\ay build is slow)
* `malloy-link` for pulling in the linked items if they were manually built
* `malloy-unlink` for breaking the workspace link