### PR TITLE
First pass at Hover Cards in the Source panel

### DIFF
--- a/src/components/HoverCard.tsx
+++ b/src/components/HoverCard.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {FieldInfo} from '@malloydata/malloy-interfaces';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipTrigger,
+} from '@radix-ui/react-tooltip';
+import stylex from '@stylexjs/stylex';
+import * as React from 'react';
+import BadgeForField from './primitives/BadgeForField';
+import {textColors} from './primitives/colors.stylex';
+import {fontStyles} from './primitives/styles';
+
+interface HoverCardContentProps {
+  /**
+   * The field information associated with the field token.
+   */
+  field: FieldInfo;
+
+  /**
+   * The different items in the path to the field.
+   */
+  pathParts: string[];
+}
+
+interface HoverCardProps extends HoverCardContentProps {
+  children: React.ReactElement;
+}
+
+/**
+ * Renders the a hover card for a field when the user hovers over the
+ * children of this component.
+ **/
+export default function HoverCard({
+  field,
+  children,
+  pathParts,
+}: HoverCardProps) {
+  return (
+    <Tooltip>
+      <TooltipPortal />
+      <TooltipTrigger asChild>
+        <div>{children}</div>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        <HoverCardContent field={field} pathParts={pathParts} />
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function HoverCardContent({field, pathParts}: HoverCardContentProps) {
+  const pathString = [...pathParts, field.name].join(' > ');
+  const descriptionAnnotation = field.annotations?.find(a =>
+    a.value.startsWith('#"')
+  );
+  const description = descriptionAnnotation
+    ? descriptionAnnotation.value.substring(2)
+    : 'This is a ' + field.kind + '.';
+
+  const details = null;
+
+  return (
+    <div {...stylex.props(styles.container, fontStyles.body)}>
+      <div {...stylex.props(styles.metadataSection)}>
+        <div {...stylex.props(styles.badge)}>
+          <BadgeForField field={field} />
+        </div>
+        <div {...stylex.props(fontStyles.supporting, styles.path)}>
+          {pathString}
+        </div>
+        <div {...stylex.props(fontStyles.emphasized)}>{field.name}</div>
+        {description && <div>{description}</div>}
+      </div>
+      {details && <div {...stylex.props(styles.detailsSection)}>{details}</div>}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    width: '323px',
+    maxHeight: '248px',
+
+    boxShadow:
+      '0 1px 2px 0 rgba(0, 0, 0, 0.1), 0 2px 12px 0 rgba(0, 0, 0, 0.1)',
+    backgroundColor: 'white',
+    borderRadius: '12px',
+    padding: '12px',
+
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  metadataSection: {},
+  badge: {
+    marginBottom: '4px',
+  },
+  path: {
+    color: textColors.secondary,
+  },
+  detailsSection: {},
+});

--- a/src/components/QueryPanel/QueryPanel.tsx
+++ b/src/components/QueryPanel/QueryPanel.tsx
@@ -49,7 +49,7 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     flexShrink: 0,
-    width: '640px',
+    width: '360px',
     background: 'rgba(255, 255, 255, 1)',
     borderRight: '1px solid rgba(204, 211, 219, 1)',
   },

--- a/src/components/SourcePanel/FieldTokenWithActions.tsx
+++ b/src/components/SourcePanel/FieldTokenWithActions.tsx
@@ -5,6 +5,7 @@ import {Button} from '../primitives';
 import {QueryEditorContext} from '../../contexts/QueryEditorContext';
 import {Menu, MenuItem} from '../Menu';
 import {useQueryOperations} from './hooks/useQueryOperations';
+import HoverCard from '../HoverCard';
 
 interface FieldTokenWithActionsProps {
   field: Malloy.FieldInfo;
@@ -110,51 +111,53 @@ export function FieldTokenWithActions({
   };
 
   return (
-    <FieldToken
-      field={field}
-      onClick={addFieldToMainQuery}
-      hasMenu={hasAddFieldMenu}
-      menuItems={addFieldMenuItems()}
-      hoverActionsVisible={isAddFieldMenuOpen || isNestFieldMenuOpen}
-      hoverActions={
-        <>
-          {hasAddFieldMenu ? (
-            <Menu
-              trigger={<Button variant="flat" size="compact" icon="insert" />}
-              items={addFieldMenuItems()}
-              onOpenChange={open => setIsAddFieldMenuOpen(open)}
-            />
-          ) : (
-            <Button
-              variant="flat"
-              size="compact"
-              icon="insert"
-              onClick={addFieldToMainQuery}
-            />
-          )}
-          {hadNestFieldMenu ? (
-            <Menu
-              trigger={
-                <Button
-                  variant="flat"
-                  size="compact"
-                  icon="nest"
-                  onClick={() => {}}
-                />
-              }
-              items={nestFieldMenuItems()}
-              onOpenChange={open => setIsNestFieldMenuOpen(open)}
-            />
-          ) : (
-            <Button
-              variant="flat"
-              size="compact"
-              icon="nest"
-              onClick={() => {}}
-            />
-          )}
-        </>
-      }
-    />
+    <HoverCard field={field} pathParts={path}>
+      <FieldToken
+        field={field}
+        onClick={addFieldToMainQuery}
+        hasMenu={hasAddFieldMenu}
+        menuItems={addFieldMenuItems()}
+        hoverActionsVisible={isAddFieldMenuOpen || isNestFieldMenuOpen}
+        hoverActions={
+          <>
+            {hasAddFieldMenu ? (
+              <Menu
+                trigger={<Button variant="flat" size="compact" icon="insert" />}
+                items={addFieldMenuItems()}
+                onOpenChange={open => setIsAddFieldMenuOpen(open)}
+              />
+            ) : (
+              <Button
+                variant="flat"
+                size="compact"
+                icon="insert"
+                onClick={addFieldToMainQuery}
+              />
+            )}
+            {hadNestFieldMenu ? (
+              <Menu
+                trigger={
+                  <Button
+                    variant="flat"
+                    size="compact"
+                    icon="nest"
+                    onClick={() => {}}
+                  />
+                }
+                items={nestFieldMenuItems()}
+                onOpenChange={open => setIsNestFieldMenuOpen(open)}
+              />
+            ) : (
+              <Button
+                variant="flat"
+                size="compact"
+                icon="nest"
+                onClick={() => {}}
+              />
+            )}
+          </>
+        }
+      />
+    </HoverCard>
   );
 }

--- a/src/components/SourcePanel/SourcePanel.tsx
+++ b/src/components/SourcePanel/SourcePanel.tsx
@@ -159,6 +159,8 @@ const styles = stylex.create({
     width: '280px',
     backgroundColor: '#F1F4F7',
     boxShadow: '-1px 0px 0px 0px #C8CCD2 inset',
+    // A positive zIndex allows nested tooltips to overlay properly.
+    zIndex: 1,
   },
   header: {
     display: 'flex',

--- a/src/components/primitives/BadgeForField.tsx
+++ b/src/components/primitives/BadgeForField.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import * as React from 'react';
+import {FieldInfo} from '@malloydata/malloy-interfaces';
+
+import Badge from './Badge';
+import stylex from '@stylexjs/stylex';
+
+interface BadgeForFieldProps {
+  field: FieldInfo;
+}
+export default function BadgeForField({field}: BadgeForFieldProps) {
+  if (field.kind === 'view') {
+    return (
+      <Badge
+        label="view"
+        icon="view_filled"
+        color="purple"
+        style={styles.noBackground}
+      />
+    );
+  } else if (field.kind === 'dimension') {
+    // TODO: dimension_filled icon?
+    return (
+      <Badge
+        label="dimension"
+        icon="dimension"
+        color="cyan"
+        style={styles.noBackground}
+      />
+    );
+  } else if (field.kind === 'measure') {
+    // TODO: measure_filled icon?
+    return (
+      <Badge
+        label="measure"
+        icon="measure"
+        color="green"
+        style={styles.noBackground}
+      />
+    );
+  } else if (field.kind === 'join') {
+    // TODO: should we use different icons for different types of joins?
+    return (
+      <Badge
+        label="join"
+        icon="many_to_one"
+        color="gray"
+        style={styles.noBackground}
+      />
+    );
+  }
+}
+
+const styles = stylex.create({
+  noBackground: {
+    backgroundColor: 'transparent',
+  },
+});


### PR DESCRIPTION
First pass at hover cards.

There are a few known issues that I'll follow up with fixes for, such as the path missing the root element and the metadata or search index content not being included. Furthermore, if a description is not found, one is made up which will also change.

<img width="866" alt="image" src="https://github.com/user-attachments/assets/523d9e33-7df0-4a7a-aa83-13c20102ba9a" />
