### PR TITLE
Fix path computation for hover cards

### DIFF
--- a/src/components/HoverCard.tsx
+++ b/src/components/HoverCard.tsx
@@ -57,7 +57,7 @@ export default function HoverCard({
 }
 
 function HoverCardContent({field, pathParts}: HoverCardContentProps) {
-  const pathString = [...pathParts, field.name].join(' > ');
+  const pathString = pathParts.join(' > ');
   const descriptionAnnotation = field.annotations?.find(a =>
     a.value.startsWith('#"')
   );

--- a/src/components/SourcePanel/FieldGroupList.tsx
+++ b/src/components/SourcePanel/FieldGroupList.tsx
@@ -18,8 +18,8 @@ const getLabelFromPath = (source: SourceInfo, path: string[]) => {
 };
 
 const getSublabelFromPath = (source: SourceInfo, path: string[]) => {
-  return path.length > 0
-    ? `joined to ${[...path.slice(0, -1), source.name].join(' > ')}`
+  return path.length > 1
+    ? `joined to ${[...path.slice(1, -1), source.name].join(' > ')}`
     : undefined;
 };
 

--- a/src/components/SourcePanel/utils.ts
+++ b/src/components/SourcePanel/utils.ts
@@ -34,7 +34,7 @@ export function flattenFieldsTree(
 }
 
 export function sourceToFieldItems(source: SourceInfo): FieldItem[] {
-  return flattenFieldsTree(source.schema.fields);
+  return flattenFieldsTree(source.schema.fields, [source.name]);
 }
 
 export function groupFieldItemsByPath(


### PR DESCRIPTION
Correctly include the root source in the path and exclude the property name which is rendered just below.

<img width="570" alt="image" src="https://github.com/user-attachments/assets/5e24df58-057f-4b83-adcb-b2167c0ee9ef" />
