### PR TITLE
Hover card changes to path object breaks compatibility with query bui…

### DIFF
--- a/src/components/HoverCard.tsx
+++ b/src/components/HoverCard.tsx
@@ -18,6 +18,7 @@ import BadgeForField from './primitives/BadgeForField';
 import {textColors} from './primitives/colors.stylex';
 import {fontStyles} from './primitives/styles';
 import ViewAttributeTable from './ResultPanel/ViewAttributeTable';
+import {QueryEditorContext} from '../contexts/QueryEditorContext';
 
 interface HoverCardContentProps {
   /**
@@ -61,7 +62,9 @@ export default function HoverCard({
 }
 
 function HoverCardContent({field, pathParts}: HoverCardContentProps) {
-  const pathString = pathParts.join(' > ');
+  const {source} = React.useContext(QueryEditorContext);
+
+  const pathString = [source?.name ?? '', ...pathParts].join(' > ');
   const descriptionAnnotation = field.annotations?.find(a =>
     a.value.startsWith('#"')
   );

--- a/src/components/MalloyExplorerProvider.tsx
+++ b/src/components/MalloyExplorerProvider.tsx
@@ -28,7 +28,7 @@ export function MalloyExplorerProvider({
   const rootQuery = useQueryBuilder(source, query);
   return (
     <TooltipProvider>
-      <QueryEditorContext.Provider value={{rootQuery, setQuery}}>
+      <QueryEditorContext.Provider value={{source, rootQuery, setQuery}}>
         {children}
       </QueryEditorContext.Provider>
     </TooltipProvider>

--- a/src/components/SourcePanel/FieldGroupList.tsx
+++ b/src/components/SourcePanel/FieldGroupList.tsx
@@ -18,8 +18,8 @@ const getLabelFromPath = (source: SourceInfo, path: string[]) => {
 };
 
 const getSublabelFromPath = (source: SourceInfo, path: string[]) => {
-  return path.length > 1
-    ? `joined to ${[...path.slice(1, -1), source.name].join(' > ')}`
+  return path.length > 0
+    ? `joined to ${[...path.slice(0, -1), source.name].join(' > ')}`
     : undefined;
 };
 

--- a/src/components/SourcePanel/utils.ts
+++ b/src/components/SourcePanel/utils.ts
@@ -36,7 +36,7 @@ export function flattenFieldsTree(
 }
 
 export function sourceToFieldItems(source: SourceInfo): FieldItem[] {
-  return flattenFieldsTree(source.schema.fields, [source.name]);
+  return flattenFieldsTree(source.schema.fields);
 }
 
 export function groupFieldItemsByPath(

--- a/src/contexts/QueryEditorContext.ts
+++ b/src/contexts/QueryEditorContext.ts
@@ -10,6 +10,8 @@ import * as Malloy from '@malloydata/malloy-interfaces';
 import {ASTQuery} from '@malloydata/malloy-query-builder';
 
 export interface QueryEditorContextProps {
+  /** Source object at the root level */
+  source?: Malloy.SourceInfo;
   /** Query object to represent current state at the root level  */
   rootQuery?: ASTQuery;
   /** Provide to allow editing of the query */


### PR DESCRIPTION
Path object must be compatible with the definition of join path used by Malloy Query Builder package and its operations. It should not be changed for UI features but rather to be extended with fieldName or sourceName depending on use-case

Add source object to global context