### PR TITLE
Fix up a bunch of token styling

### DIFF
--- a/src/components/QueryPanel/LiteralValueEditor.tsx
+++ b/src/components/QueryPanel/LiteralValueEditor.tsx
@@ -8,14 +8,20 @@
 import * as React from 'react';
 import * as Malloy from '@malloydata/malloy-interfaces';
 import {RawLiteralValue} from '@malloydata/malloy-query-builder';
-import {EditableToken} from '../primitives';
+import {EditableToken, SelectorToken, Token} from '../primitives';
+import {StyleXStyles} from '@stylexjs/stylex';
 
 export interface LiteralValueEditorProps {
   value: Malloy.LiteralValue | undefined;
   setValue: (value: RawLiteralValue) => void;
+  customStyle?: StyleXStyles;
 }
 
-export function LiteralValueEditor({value, setValue}: LiteralValueEditorProps) {
+export function LiteralValueEditor({
+  value,
+  setValue,
+  customStyle,
+}: LiteralValueEditorProps) {
   if (!value) {
     return null;
   }
@@ -23,10 +29,14 @@ export function LiteralValueEditor({value, setValue}: LiteralValueEditorProps) {
   switch (value.kind) {
     case 'boolean_literal':
       return (
-        <input
-          type="checkbox"
-          checked={value.boolean_value}
-          onChange={event => setValue(event.target.checked)}
+        <SelectorToken
+          value={value.boolean_value ? 'true' : 'false'}
+          items={[
+            {label: 'true', value: 'true'},
+            {label: 'false', value: 'false'},
+          ]}
+          onChange={value => setValue(value === 'true')}
+          customStyle={customStyle}
         />
       );
     case 'date_literal':
@@ -43,13 +53,14 @@ export function LiteralValueEditor({value, setValue}: LiteralValueEditorProps) {
         />
       );
     case 'null_literal':
-      return '∅';
+      return <Token label="∅" />;
     case 'number_literal':
       return (
-        <input
+        <EditableToken
           value={value.number_value}
           type="number"
-          onChange={event => setValue(event.target.valueAsNumber)}
+          onChange={value => setValue(value)}
+          customStyle={customStyle}
         />
       );
     case 'string_literal':
@@ -57,6 +68,7 @@ export function LiteralValueEditor({value, setValue}: LiteralValueEditorProps) {
         <EditableToken
           value={value.string_value}
           onChange={value => setValue(value)}
+          customStyle={customStyle}
         />
       );
     case 'timestamp_literal':

--- a/src/components/QueryPanel/Visualization.tsx
+++ b/src/components/QueryPanel/Visualization.tsx
@@ -40,7 +40,7 @@ export function Visualization({rootQuery, view}: VisualizationProps) {
   const tokens = [
     <SelectorToken
       key="first"
-      style={styles.first}
+      customStyle={styles.first}
       icon={`viz_${currentRenderer}`}
       value={currentRenderer}
       items={vizes}

--- a/src/components/filters/PillInput.tsx
+++ b/src/components/filters/PillInput.tsx
@@ -16,7 +16,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import stylex from '@stylexjs/stylex';
+import stylex, {StyleXStyles} from '@stylexjs/stylex';
 import {useClickOutside} from '../hooks/useClickOutside';
 import {DEFAULT_TOKEN_COLOR, TokenColor} from '../primitives/tokens/types';
 import {iconVars, labelVars} from '../primitives/tokens/token.stylex';
@@ -34,6 +34,7 @@ interface PillInputProps {
   type?: string;
   focusElement?: RefObject<HTMLDivElement>;
   color?: TokenColor;
+  customStyle?: StyleXStyles;
 }
 
 export const PillInput: React.FC<PillInputProps> = ({
@@ -46,6 +47,7 @@ export const PillInput: React.FC<PillInputProps> = ({
   setValue: setControlledValue,
   focusElement,
   color = DEFAULT_TOKEN_COLOR,
+  customStyle,
 }) => {
   const [uncontrolledValue, setUncontrolledValue] = useState('');
   const [_focused, setFocused] = useState(false);
@@ -140,7 +142,7 @@ export const PillInput: React.FC<PillInputProps> = ({
 
   return (
     <div
-      {...stylex.props(styles.outer)}
+      {...stylex.props(styles.outer, customStyle)}
       onKeyUp={onKeyUp}
       onClick={() => inp.current?.focus()}
       ref={ref}
@@ -230,7 +232,7 @@ const styles = stylex.create({
     fontFamily: 'sans-serif',
     fontSize: 14,
     fontWeight: 'normal',
-    borderRadius: 5,
+    borderRadius: 4,
     border: '1px solid rgba(230, 235, 239, 1)',
     backgroundColor: 'rgba(230, 235, 239, 1)',
     padding: '2px 3px',

--- a/src/components/filters/StringFilterToken.tsx
+++ b/src/components/filters/StringFilterToken.tsx
@@ -19,6 +19,7 @@ import {atomicTypeToIcon, fieldKindToColor} from '../utils/icon';
 import {PillInput} from './PillInput';
 import {TokenColor} from '../primitives/tokens/types';
 import {useState} from 'react';
+import {StyleXStyles} from '@stylexjs/stylex';
 
 type StringFilterType =
   | 'is_equal_to'
@@ -173,10 +174,23 @@ interface StringEditorProps {
   values: string[];
   setValues(values: string[]): void;
   escape?: boolean;
+  customStyle?: StyleXStyles;
 }
 
-function StringEditor({color, values, setValues}: StringEditorProps) {
-  return <PillInput color={color} values={values} setValues={setValues} />;
+function StringEditor({
+  color,
+  values,
+  setValues,
+  customStyle,
+}: StringEditorProps) {
+  return (
+    <PillInput
+      color={color}
+      values={values}
+      setValues={setValues}
+      customStyle={customStyle}
+    />
+  );
 }
 
 function escapeValue(val: string) {

--- a/src/components/primitives/tokens/EditableToken.tsx
+++ b/src/components/primitives/tokens/EditableToken.tsx
@@ -52,7 +52,7 @@ interface EditableTokenBaseProps<T> {
   /**
    * Optional custom styles for the token.
    */
-  style?: StyleXStyles;
+  customStyle?: StyleXStyles;
   /**
    * Optional error message to show. If an error message exists, the token will
    * include error styles.
@@ -74,7 +74,7 @@ export default function EditableToken({
   icon,
   color = DEFAULT_TOKEN_COLOR,
   size = DEFAULT_TOKEN_SIZE,
-  style,
+  customStyle,
   type,
   errorMessage,
 }: EditableTokenStringProps | EditableTokenNumberProps) {
@@ -115,7 +115,7 @@ export default function EditableToken({
           tokenSizeVariants[size],
           isFocused && styles.focused,
           !!errorMessage && styles.hasError,
-          style
+          customStyle
         )}
       >
         {icon && <Icon name={icon} style={styles.icon} />}

--- a/src/components/primitives/tokens/SelectorToken.tsx
+++ b/src/components/primitives/tokens/SelectorToken.tsx
@@ -34,7 +34,7 @@ export interface SelectorTokenProps<T extends string> {
   size?: TokenSize;
   items: SelectorTokenItem<T>[];
   isSearchable?: boolean;
-  style?: StyleXStyles;
+  customStyle?: StyleXStyles;
 }
 
 export default function SelectorToken<T extends string>({
@@ -45,7 +45,7 @@ export default function SelectorToken<T extends string>({
   size = DEFAULT_TOKEN_SIZE,
   items,
   isSearchable = false,
-  style,
+  customStyle,
 }: SelectorTokenProps<T>) {
   const [searchQuery, setSearchQuery] = React.useState<string>('');
 
@@ -77,7 +77,7 @@ export default function SelectorToken<T extends string>({
           tokenSizeVariants[size],
           fontStyles.body,
           tokenStyles.label,
-          style
+          customStyle
         )}
       >
         {icon && <Icon name={icon} style={tokenStyles.icon} />}


### PR DESCRIPTION
Consistently use `customStyle` for things inside token groups, drill down customStyle for more complex tokens.