### PR TITLE
Add open/close logic on the source panel

### DIFF
--- a/src/components/MalloyExplorerProvider.tsx
+++ b/src/components/MalloyExplorerProvider.tsx
@@ -6,11 +6,12 @@
  */
 
 import * as React from 'react';
-import {ReactNode} from 'react';
+import {ReactNode, useState} from 'react';
 import {TooltipProvider} from '@radix-ui/react-tooltip';
 import * as Malloy from '@malloydata/malloy-interfaces';
 import {QueryEditorContext} from '../contexts/QueryEditorContext';
 import {useQueryBuilder} from '../hooks/useQueryBuilder';
+import {ExplorerPanelsContext} from '../contexts/ExplorerPanelsContext';
 
 export interface MalloyExplorerProviderProps {
   source: Malloy.SourceInfo;
@@ -25,11 +26,22 @@ export function MalloyExplorerProvider({
   setQuery,
   children,
 }: MalloyExplorerProviderProps) {
+  const [isSourcePanelOpen, setIsSourcePanelOpen] = useState(true);
   const rootQuery = useQueryBuilder(source, query);
   return (
     <TooltipProvider>
-      <QueryEditorContext.Provider value={{source, rootQuery, setQuery}}>
-        {children}
+      <QueryEditorContext.Provider
+        value={{
+          source,
+          rootQuery,
+          setQuery,
+        }}
+      >
+        <ExplorerPanelsContext.Provider
+          value={{isSourcePanelOpen, setIsSourcePanelOpen}}
+        >
+          {children}
+        </ExplorerPanelsContext.Provider>
       </QueryEditorContext.Provider>
     </TooltipProvider>
   );

--- a/src/components/QueryPanel/QueryEditor.tsx
+++ b/src/components/QueryPanel/QueryEditor.tsx
@@ -30,12 +30,7 @@ export interface QueryEditorProps {
  * @param showSource (optional)
  * @returns
  */
-export function QueryEditor({
-  source,
-  query,
-  setQuery,
-  showSource = true,
-}: QueryEditorProps) {
+export function QueryEditor({source, query, setQuery}: QueryEditorProps) {
   const rootQuery = useQueryBuilder(source, query);
 
   if (!rootQuery) {
@@ -44,7 +39,7 @@ export function QueryEditor({
 
   return (
     <div {...stylex.props(queryExplorerStyles.main)}>
-      {showSource && <Source rootQuery={rootQuery} />}
+      <Source rootQuery={rootQuery} />
       <Parameters rootQuery={rootQuery} />
       <Query rootQuery={rootQuery} query={rootQuery} setQuery={setQuery} />
     </div>

--- a/src/components/QueryPanel/QueryPanel.tsx
+++ b/src/components/QueryPanel/QueryPanel.tsx
@@ -23,7 +23,6 @@ interface QueryPanelProps {
 export default function QueryPanel({
   source,
   query,
-  showSource = true,
   setQuery,
   runQuery,
 }: QueryPanelProps) {
@@ -39,12 +38,7 @@ export default function QueryPanel({
       </div>
       <ScrollableArea>
         <div {...stylex.props(styles.content)}>
-          <QueryEditor
-            source={source}
-            query={query}
-            setQuery={setQuery}
-            showSource={showSource}
-          />
+          <QueryEditor source={source} query={query} setQuery={setQuery} />
         </div>
       </ScrollableArea>
     </div>

--- a/src/components/QueryPanel/Source.tsx
+++ b/src/components/QueryPanel/Source.tsx
@@ -11,8 +11,10 @@ import {
   ASTQuery,
 } from '@malloydata/malloy-query-builder';
 import stylex from '@stylexjs/stylex';
-import {styles} from '../styles';
-import {Icon} from '../primitives';
+import {styles as componentStyles} from '../styles';
+import {Button, Icon} from '../primitives';
+import {ExplorerPanelsContext} from '../../contexts/ExplorerPanelsContext';
+import {useContext} from 'react';
 
 /**
  * Source
@@ -22,10 +24,16 @@ export interface SourceProps {
 }
 
 export function Source({rootQuery}: SourceProps) {
-  if (rootQuery.definition instanceof ASTArrowQueryDefinition) {
+  const {isSourcePanelOpen, setIsSourcePanelOpen} = useContext(
+    ExplorerPanelsContext
+  );
+  if (
+    !isSourcePanelOpen &&
+    rootQuery.definition instanceof ASTArrowQueryDefinition
+  ) {
     return (
-      <div {...stylex.props(styles.queryCard)}>
-        <div {...stylex.props(styles.labelWithIcon)}>
+      <div {...stylex.props(componentStyles.queryCard, styles.flex)}>
+        <div {...stylex.props(componentStyles.labelWithIcon)}>
           <Icon name="database" />
           {
             rootQuery.definition.as
@@ -33,8 +41,20 @@ export function Source({rootQuery}: SourceProps) {
               .source.as.ReferenceQueryArrowSource().name
           }
         </div>
+        <Button
+          variant="flat"
+          onClick={() => setIsSourcePanelOpen(true)}
+          label="Open data panel"
+        />
       </div>
     );
   }
   return null;
 }
+
+const styles = stylex.create({
+  flex: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+});

--- a/src/components/SourcePanel/SourcePanel.tsx
+++ b/src/components/SourcePanel/SourcePanel.tsx
@@ -29,6 +29,8 @@ import {
 } from './utils';
 import SearchResultList from './SearchResultList';
 import FieldGroupList from './FieldGroupList';
+import {useContext} from 'react';
+import {ExplorerPanelsContext} from '../../contexts/ExplorerPanelsContext';
 
 export interface SourcePanelProps {
   source: Malloy.SourceInfo;
@@ -41,6 +43,9 @@ type SubpanelType = 'view' | 'dimension' | 'measure' | null;
 export function SourcePanel({source}: SourcePanelProps) {
   const [subpanelType, setSubpanelType] = React.useState<SubpanelType>(null);
   const [searchQuery, setSearchQuery] = React.useState<string>('');
+  const {isSourcePanelOpen, setIsSourcePanelOpen} = useContext(
+    ExplorerPanelsContext
+  );
 
   const fieldItems = React.useMemo(() => {
     return sourceToFieldItems(source);
@@ -78,10 +83,14 @@ export function SourcePanel({source}: SourcePanelProps) {
 
   const isSearchActive = !!searchQuery;
 
+  if (!isSourcePanelOpen) {
+    return null;
+  }
+
   return (
     <div {...stylex.props(styles.main)}>
       <div {...stylex.props(fontStyles.body, styles.header)}>
-        <div>
+        <div {...stylex.props(styles.headerTopRow)}>
           {subpanelType == null ? (
             <div {...stylex.props(styles.heading)}>
               <Icon name="database" color="gray" />
@@ -96,6 +105,13 @@ export function SourcePanel({source}: SourcePanelProps) {
               onClick={() => setSubpanelType(null)}
             />
           )}
+          <div>
+            <Button
+              icon="chevronLeft"
+              tooltip="Close the source panel"
+              onClick={() => setIsSourcePanelOpen(false)}
+            />
+          </div>
         </div>
         <TextInput
           value={searchQuery}
@@ -171,6 +187,10 @@ const styles = stylex.create({
     color: textColors.primary,
     fontWeight: 700,
     gap: '8px',
+  },
+  headerTopRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
   },
   heading: {
     display: 'flex',

--- a/src/contexts/ExplorerPanelsContext.ts
+++ b/src/contexts/ExplorerPanelsContext.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from 'react';
+
+export interface ExplorerPanelsContextProps {
+  /** Manages the state of the source panel UI.  */
+  isSourcePanelOpen: boolean;
+  setIsSourcePanelOpen: (isOpen: boolean) => void;
+}
+
+/**
+ * QueryEditorContext contains state that is shared across the different
+ * panels of the Malloy Explorer.
+ */
+
+export const ExplorerPanelsContext =
+  React.createContext<ExplorerPanelsContextProps>({
+    isSourcePanelOpen: true,
+    setIsSourcePanelOpen: () => {},
+  });


### PR DESCRIPTION
Add a context for managing shared UI state and a button to close the source panel and a button to open it again.

<img width="519" alt="image" src="https://github.com/user-attachments/assets/7658f9f5-3c57-4c32-8beb-4a45b9df7d43" />


<img width="519" alt="image" src="https://github.com/user-attachments/assets/1839380c-deeb-4a09-b5b1-99f6494682e7" />
