### PR TITLE
Don't assume the existence of the source panel

### DIFF
--- a/dev/MalloyExplorer.tsx
+++ b/dev/MalloyExplorer.tsx
@@ -15,38 +15,45 @@ import {modelInfo} from './sample_models/example_model';
 import stylex from '@stylexjs/stylex';
 import {QueryPanel} from '../src/components/QueryPanel';
 import {fontStyles} from '../src/components/primitives/styles';
+import {ExplorerPanelsContext} from '../src/contexts/ExplorerPanelsContext';
 
 const source = modelInfo.entries.at(-1) as Malloy.SourceInfo;
 
 const App = () => {
   const [query, setQuery] = useState<Malloy.Query | undefined>();
+  const [isSourcePanelOpen, setIsSourcePanelOpen] = useState(true);
+
   return (
     <React.StrictMode>
       <MalloyExplorerProvider source={source} query={query} setQuery={setQuery}>
-        <div {...stylex.props(styles.page)}>
-          <div {...stylex.props(fontStyles.body, styles.banner)}>
-            WARNING: This page shows all the components beside each other, but
-            they do not actually work correctly yet.
+        <ExplorerPanelsContext.Provider
+          value={{isSourcePanelOpen, setIsSourcePanelOpen}}
+        >
+          <div {...stylex.props(styles.page)}>
+            <div {...stylex.props(fontStyles.body, styles.banner)}>
+              WARNING: This page shows all the components beside each other, but
+              they do not actually work correctly yet.
+            </div>
+            <div {...stylex.props(styles.content)}>
+              <SourcePanel source={source} query={query} setQuery={setQuery} />
+              <QueryPanel
+                source={source}
+                query={query}
+                setQuery={setQuery}
+                runQuery={(source, query) => {
+                  const qb = new QueryBuilder.ASTQuery({source, query});
+                  window.alert(qb.toMalloy());
+                }}
+                showSource={false}
+              />
+              <ResultPanel
+                source={source}
+                draftQuery={query}
+                setDraftQuery={setQuery}
+              />
+            </div>
           </div>
-          <div {...stylex.props(styles.content)}>
-            <SourcePanel source={source} query={query} setQuery={setQuery} />
-            <QueryPanel
-              source={source}
-              query={query}
-              setQuery={setQuery}
-              runQuery={(source, query) => {
-                const qb = new QueryBuilder.ASTQuery({source, query});
-                window.alert(qb.toMalloy());
-              }}
-              showSource={false}
-            />
-            <ResultPanel
-              source={source}
-              draftQuery={query}
-              setDraftQuery={setQuery}
-            />
-          </div>
-        </div>
+        </ExplorerPanelsContext.Provider>
       </MalloyExplorerProvider>
     </React.StrictMode>
   );

--- a/src/components/MalloyExplorerProvider.tsx
+++ b/src/components/MalloyExplorerProvider.tsx
@@ -6,12 +6,11 @@
  */
 
 import * as React from 'react';
-import {ReactNode, useState} from 'react';
+import {ReactNode} from 'react';
 import {TooltipProvider} from '@radix-ui/react-tooltip';
 import * as Malloy from '@malloydata/malloy-interfaces';
 import {QueryEditorContext} from '../contexts/QueryEditorContext';
 import {useQueryBuilder} from '../hooks/useQueryBuilder';
-import {ExplorerPanelsContext} from '../contexts/ExplorerPanelsContext';
 
 export interface MalloyExplorerProviderProps {
   source: Malloy.SourceInfo;
@@ -26,7 +25,6 @@ export function MalloyExplorerProvider({
   setQuery,
   children,
 }: MalloyExplorerProviderProps) {
-  const [isSourcePanelOpen, setIsSourcePanelOpen] = useState(true);
   const rootQuery = useQueryBuilder(source, query);
   return (
     <TooltipProvider>
@@ -37,11 +35,7 @@ export function MalloyExplorerProvider({
           setQuery,
         }}
       >
-        <ExplorerPanelsContext.Provider
-          value={{isSourcePanelOpen, setIsSourcePanelOpen}}
-        >
-          {children}
-        </ExplorerPanelsContext.Provider>
+        {children}
       </QueryEditorContext.Provider>
     </TooltipProvider>
   );

--- a/src/components/QueryPanel/QueryEditor.tsx
+++ b/src/components/QueryPanel/QueryEditor.tsx
@@ -18,7 +18,6 @@ export interface QueryEditorProps {
   source: Malloy.SourceInfo;
   query?: Malloy.Query;
   setQuery?: (query: Malloy.Query | undefined) => void;
-  showSource?: boolean;
 }
 
 /**
@@ -27,7 +26,6 @@ export interface QueryEditorProps {
  *
  * @param source The source object to be used for query building.
  * @param query A query to be edited. Omit for a new query.
- * @param showSource (optional)
  * @returns
  */
 export function QueryEditor({source, query, setQuery}: QueryEditorProps) {

--- a/src/components/QueryPanel/Source.tsx
+++ b/src/components/QueryPanel/Source.tsx
@@ -27,12 +27,6 @@ export function Source({rootQuery}: SourceProps) {
   const {isSourcePanelOpen, setIsSourcePanelOpen} = useContext(
     ExplorerPanelsContext
   );
-  console.info(
-    'xxx',
-    isSourcePanelOpen,
-    setIsSourcePanelOpen,
-    !(isSourcePanelOpen && setIsSourcePanelOpen)
-  );
   if (
     !(isSourcePanelOpen && setIsSourcePanelOpen) &&
     rootQuery.definition instanceof ASTArrowQueryDefinition

--- a/src/components/QueryPanel/Source.tsx
+++ b/src/components/QueryPanel/Source.tsx
@@ -27,8 +27,14 @@ export function Source({rootQuery}: SourceProps) {
   const {isSourcePanelOpen, setIsSourcePanelOpen} = useContext(
     ExplorerPanelsContext
   );
+  console.info(
+    'xxx',
+    isSourcePanelOpen,
+    setIsSourcePanelOpen,
+    !(isSourcePanelOpen && setIsSourcePanelOpen)
+  );
   if (
-    !isSourcePanelOpen &&
+    !(isSourcePanelOpen && setIsSourcePanelOpen) &&
     rootQuery.definition instanceof ASTArrowQueryDefinition
   ) {
     return (
@@ -41,11 +47,13 @@ export function Source({rootQuery}: SourceProps) {
               .source.as.ReferenceQueryArrowSource().name
           }
         </div>
-        <Button
-          variant="flat"
-          onClick={() => setIsSourcePanelOpen(true)}
-          label="Open data panel"
-        />
+        {setIsSourcePanelOpen && (
+          <Button
+            variant="flat"
+            onClick={() => setIsSourcePanelOpen(true)}
+            label="Open data panel"
+          />
+        )}
       </div>
     );
   }

--- a/src/components/SourcePanel/SourcePanel.tsx
+++ b/src/components/SourcePanel/SourcePanel.tsx
@@ -105,13 +105,15 @@ export function SourcePanel({source}: SourcePanelProps) {
               onClick={() => setSubpanelType(null)}
             />
           )}
-          <div>
-            <Button
-              icon="chevronLeft"
-              tooltip="Close the source panel"
-              onClick={() => setIsSourcePanelOpen(false)}
-            />
-          </div>
+          {setIsSourcePanelOpen && (
+            <div>
+              <Button
+                icon="chevronLeft"
+                tooltip="Close the source panel"
+                onClick={() => setIsSourcePanelOpen(false)}
+              />
+            </div>
+          )}
         </div>
         <TextInput
           value={searchQuery}

--- a/src/contexts/ExplorerPanelsContext.ts
+++ b/src/contexts/ExplorerPanelsContext.ts
@@ -10,7 +10,7 @@ import * as React from 'react';
 export interface ExplorerPanelsContextProps {
   /** Manages the state of the source panel UI.  */
   isSourcePanelOpen: boolean;
-  setIsSourcePanelOpen: (isOpen: boolean) => void;
+  setIsSourcePanelOpen?: (isOpen: boolean) => void;
 }
 
 /**
@@ -21,5 +21,5 @@ export interface ExplorerPanelsContextProps {
 export const ExplorerPanelsContext =
   React.createContext<ExplorerPanelsContextProps>({
     isSourcePanelOpen: true,
-    setIsSourcePanelOpen: () => {},
+    setIsSourcePanelOpen: undefined,
   });


### PR DESCRIPTION
The QueryEditor is designed to be a stand-alone editor if necessary, it shouldn't be tied to the Source panel state.