### PR TITLE
center result loading indicator

### DIFF
--- a/dev/sample_models/example_model.ts
+++ b/dev/sample_models/example_model.ts
@@ -2341,6 +2341,46 @@ ORDER BY 1 asc NULLS LAST
       },
       {
         kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
+        record_value: [{kind: 'string_cell', string_value: 'WN'}],
+      },
+      {
+        kind: 'record_cell',
         record_value: [{kind: 'string_cell', string_value: 'AA'}],
       },
     ],

--- a/src/components/ResultPanel/ResultDisplay.tsx
+++ b/src/components/ResultPanel/ResultDisplay.tsx
@@ -8,7 +8,7 @@
 import * as React from 'react';
 import * as Malloy from '@malloydata/malloy-interfaces';
 import stylex from '@stylexjs/stylex';
-import {Button, Spinner} from '../primitives';
+import {Button, ScrollableArea, Spinner} from '../primitives';
 import {fontStyles} from '../primitives/styles';
 import {
   EXECUTION_STATES,
@@ -97,13 +97,13 @@ function FinishedResultDisplay({result}: FinishedResultDisplay) {
   }, [result]);
 
   return (
-    <div>
+    <ScrollableArea>
       {rendering ? (
         <Spinner size="large" />
       ) : (
         <div>{html && <DOMElement element={html} />}</div>
       )}
-    </div>
+    </ScrollableArea>
   );
 }
 

--- a/src/components/ResultPanel/ResultPanel.tsx
+++ b/src/components/ResultPanel/ResultPanel.tsx
@@ -144,9 +144,7 @@ export default function ResultPanel({
                     <span> to the last run query.</span>
                   </div>
                 )}
-              <ScrollableArea>
-                <ResultDisplay query={submittedQuery} />
-              </ScrollableArea>
+              <ResultDisplay query={submittedQuery} />
             </>
           )}
         </Content>

--- a/src/components/ResultPanel/ResultPanel.tsx
+++ b/src/components/ResultPanel/ResultPanel.tsx
@@ -12,7 +12,7 @@ import {Content, List, Root, Trigger} from '@radix-ui/react-tabs';
 import stylex from '@stylexjs/stylex';
 import {backgroundColors, textColors} from '../primitives/colors.stylex';
 import {fontStyles} from '../primitives/styles';
-import {Button, CodeBlock, Icon, ScrollableArea} from '../primitives';
+import {Button, CodeBlock, Icon} from '../primitives';
 import ResultDisplay from './ResultDisplay';
 import {SubmittedQuery} from './SubmittedQuery';
 import {useQueryBuilder} from '../../hooks/useQueryBuilder';


### PR DESCRIPTION
Behavior change here is loading messages stay centered in parent container. 

Results still scroll as before