### PR TITLE
Small Results panel styling tweaks

### DIFF
--- a/src/components/ResultPanel/ResultPanel.tsx
+++ b/src/components/ResultPanel/ResultPanel.tsx
@@ -290,6 +290,7 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     border: 'none',
     padding: '0px',
+    cursor: 'pointer',
   },
   warningIcon: {
     paddingRight: '8px',

--- a/src/components/primitives/syntax_highlighting/transformers/lineNumberTransformer.ts
+++ b/src/components/primitives/syntax_highlighting/transformers/lineNumberTransformer.ts
@@ -20,6 +20,7 @@ const getLineNumberTransformer: GetTransformer = ({
             'margin-right: 35px;',
             'width: 1px;',
             'display: inline-block;',
+            'user-select: none',
           ],
         },
       };


### PR DESCRIPTION
1. Add a cursor to the 'revert' link
2. Disable text selection on line numbers