### PR TITLE
Various UX changes

### DIFF
--- a/src/components/QueryPanel/ViewDefinition.tsx
+++ b/src/components/QueryPanel/ViewDefinition.tsx
@@ -122,7 +122,6 @@ const styles = stylex.create({
     gap: 8,
     borderRadius: '4px',
     borderWidth: 0,
-    cursor: 'pointer',
     position: 'relative',
     overflow: 'hidden',
     background: 'rgba(230, 235, 239, 1)',

--- a/src/components/ResultPanel/EmptyQueryDisplay.tsx
+++ b/src/components/ResultPanel/EmptyQueryDisplay.tsx
@@ -48,6 +48,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     width: '100%',
     height: '100%',
+    overflow: 'auto',
   },
   pageChild: {
     margin: 'auto',

--- a/src/components/primitives/CollapsibleListItem.tsx
+++ b/src/components/primitives/CollapsibleListItem.tsx
@@ -94,7 +94,7 @@ const styles = stylex.create({
   content: {
     display: 'flex',
     flexDirection: 'column',
-    padding: '4px 0px 8px 32px',
+    padding: '4px 0px 8px 0px',
     gap: '4px',
   },
 });


### PR DESCRIPTION
1. Remove the 'pointer' on hover over the 'view' card collapsible header
2. Align the items in the Sources panel with the chevron to save horizontal space per item 4 [here](https://docs.google.com/document/d/1Fix6-Aiw27jkjHOzId5dM7z4gE8W2C0SOl-uyQBl9_Y/edit?tab=t.0)
3. Make the empty state results panel height: 100% so it does not cause the page to grow


<img width="247" alt="image" src="https://github.com/user-attachments/assets/4c53431b-6d43-4995-8dbf-4e0b91b042c7" />

<img width="517" alt="image" src="https://github.com/user-attachments/assets/d02dd05d-cad2-4934-bd3d-c40fa94cc1d9" />
