### PR TITLE
Avoid calling getOrAddDefaultSegment unnecessarily, take 2

### DIFF
--- a/src/components/QueryPanel/AddMenu/AddAggregate.tsx
+++ b/src/components/QueryPanel/AddMenu/AddAggregate.tsx
@@ -7,31 +7,34 @@
 
 import * as React from 'react';
 import {useContext} from 'react';
-import {
-  ASTQuery,
-  ASTSegmentViewDefinition,
-} from '@malloydata/malloy-query-builder';
+import {ASTQuery} from '@malloydata/malloy-query-builder';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import {AddFieldItem} from './AddFieldItem';
+import {
+  getInputSchemaFromViewParent,
+  viewParentDoesNotHaveField,
+  ViewParent,
+} from '../../utils/fields';
 
 export interface AddAggregateProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
 }
 
-export function AddAggregate({rootQuery, segment}: AddAggregateProps) {
+export function AddAggregate({rootQuery, view}: AddAggregateProps) {
   const {setQuery} = useContext(QueryEditorContext);
-  const {fields} = segment.getInputSchema();
+  const {fields} = getInputSchemaFromViewParent(view);
 
   return (
     <AddFieldItem
       label="Add aggregate"
       icon="aggregate"
-      segment={segment}
+      view={view}
       fields={fields}
       types={['measure']}
-      filter={(segment, field, path) => !segment.hasField(field.name, path)}
+      filter={viewParentDoesNotHaveField}
       onClick={(field, path) => {
+        const segment = view.getOrAddDefaultSegment();
         segment.addAggregate(field.name, path);
         setQuery?.(rootQuery.build());
       }}

--- a/src/components/QueryPanel/AddMenu/AddEmptyNest.tsx
+++ b/src/components/QueryPanel/AddMenu/AddEmptyNest.tsx
@@ -7,30 +7,28 @@
 
 import * as React from 'react';
 import {useContext} from 'react';
-import {
-  ASTQuery,
-  ASTSegmentViewDefinition,
-} from '@malloydata/malloy-query-builder';
+import {ASTQuery} from '@malloydata/malloy-query-builder';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import Icon from '../../primitives/Icon';
 import {AddItem} from './AddItem';
 import {segmentNestNo} from '../../utils/segment';
+import {ViewParent} from '../../utils/fields';
 
 export interface AddEmptyNestProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
 }
 
-export function AddEmptyNest({rootQuery, segment}: AddEmptyNestProps) {
+export function AddEmptyNest({rootQuery, view}: AddEmptyNestProps) {
   const {setQuery} = useContext(QueryEditorContext);
-
-  const nestNo = segmentNestNo(segment, `Nest`);
 
   return (
     <AddItem
       icon={<Icon name="nest" />}
       label="Add blank nested query"
       onClick={() => {
+        const segment = view.getOrAddDefaultSegment();
+        const nestNo = segmentNestNo(segment, `Nest`);
         segment.addEmptyNest(nestNo > 1 ? `Nest ${nestNo}` : `Nest`);
         setQuery?.(rootQuery.build());
       }}

--- a/src/components/QueryPanel/AddMenu/AddFieldItem.tsx
+++ b/src/components/QueryPanel/AddMenu/AddFieldItem.tsx
@@ -8,7 +8,6 @@
 import * as React from 'react';
 import {useState} from 'react';
 import * as Malloy from '@malloydata/malloy-interfaces';
-import {ASTSegmentViewDefinition} from '@malloydata/malloy-query-builder';
 import Icon from '../../primitives/Icon';
 import {addMenuStyles} from './styles';
 import stylex from '@stylexjs/stylex';
@@ -23,16 +22,17 @@ import {
   TooltipTrigger,
 } from '@radix-ui/react-tooltip';
 import {fontStyles, tooltipStyles} from '../../primitives/styles';
+import {ViewParent} from '../../utils/fields';
 
 export interface AddGroupByProps {
   label: string;
   icon: IconType;
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
   fields: FieldInfo[];
   onClick(field: FieldInfo, path: string[]): void;
   types: Array<'dimension' | 'measure' | 'view'>;
   filter?: (
-    segment: ASTSegmentViewDefinition,
+    view: ViewParent,
     field: Malloy.FieldInfo,
     path: string[]
   ) => boolean;
@@ -40,7 +40,7 @@ export interface AddGroupByProps {
 }
 
 export function AddFieldItem({
-  segment,
+  view,
   fields,
   icon,
   label,
@@ -99,7 +99,7 @@ export function AddFieldItem({
           <FieldMenu
             types={types}
             filter={filter}
-            segment={segment}
+            view={view}
             fields={fields}
             onClick={onClick}
           />

--- a/src/components/QueryPanel/AddMenu/AddGroupBy.tsx
+++ b/src/components/QueryPanel/AddMenu/AddGroupBy.tsx
@@ -7,32 +7,35 @@
 
 import * as React from 'react';
 import {useContext} from 'react';
-import {
-  ASTQuery,
-  ASTSegmentViewDefinition,
-} from '@malloydata/malloy-query-builder';
+import {ASTQuery} from '@malloydata/malloy-query-builder';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import {addGroupBy} from '../../utils/segment';
 import {AddFieldItem} from './AddFieldItem';
+import {
+  viewParentDoesNotHaveField,
+  ViewParent,
+  getInputSchemaFromViewParent,
+} from '../../utils/fields';
 
 export interface AddGroupByProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
 }
 
-export function AddGroupBy({rootQuery, segment}: AddGroupByProps) {
+export function AddGroupBy({rootQuery, view}: AddGroupByProps) {
   const {setQuery} = useContext(QueryEditorContext);
-  const {fields} = segment.getInputSchema();
+  const {fields} = getInputSchemaFromViewParent(view);
 
   return (
     <AddFieldItem
       label="Add group by"
       icon="groupBy"
-      segment={segment}
+      view={view}
       fields={fields}
       types={['dimension']}
-      filter={(segment, field, path) => !segment.hasField(field.name, path)}
+      filter={viewParentDoesNotHaveField}
       onClick={(field, path) => {
+        const segment = view.getOrAddDefaultSegment();
         addGroupBy(rootQuery, segment, field, path, setQuery);
       }}
     />

--- a/src/components/QueryPanel/AddMenu/AddLimit.tsx
+++ b/src/components/QueryPanel/AddMenu/AddLimit.tsx
@@ -6,25 +6,24 @@
  */
 
 import * as React from 'react';
-import {useContext, useMemo} from 'react';
-import {
-  ASTQuery,
-  ASTSegmentViewDefinition,
-} from '@malloydata/malloy-query-builder';
+import {useContext} from 'react';
+import {ASTQuery} from '@malloydata/malloy-query-builder';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import Icon from '../../primitives/Icon';
 import {AddItem} from './AddItem';
-import {segmentHasLimit} from '../../utils/segment';
+import {getSegmentIfPresent, segmentHasLimit} from '../../utils/segment';
+import {ViewParent} from '../../utils/fields';
 
 export interface AddLimitProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
 }
 
-export function AddLimit({rootQuery, segment}: AddLimitProps) {
+export function AddLimit({rootQuery, view}: AddLimitProps) {
   const {setQuery} = useContext(QueryEditorContext);
 
-  const hasLimit = useMemo(() => segmentHasLimit(segment), [segment]);
+  const segment = getSegmentIfPresent(view);
+  const hasLimit = segment ? segmentHasLimit(segment) : false;
 
   return (
     <AddItem
@@ -32,6 +31,7 @@ export function AddLimit({rootQuery, segment}: AddLimitProps) {
       label="Limit"
       disable={() => hasLimit}
       onClick={() => {
+        const segment = view.getOrAddDefaultSegment();
         segment.setLimit(10);
         setQuery?.(rootQuery.build());
       }}

--- a/src/components/QueryPanel/AddMenu/AddMenu.tsx
+++ b/src/components/QueryPanel/AddMenu/AddMenu.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react';
 import {useContext, useState} from 'react';
-import {ASTView, ASTQuery} from '@malloydata/malloy-query-builder';
+import {ASTQuery} from '@malloydata/malloy-query-builder';
 import * as Popover from '@radix-ui/react-popover';
 import stylex from '@stylexjs/stylex';
 import {Button, Divider, TextInput} from '../../primitives';
@@ -25,18 +25,17 @@ import {FieldList} from './FieldList';
 import {segmentHasLimit, segmentNestNo} from '../../utils/segment';
 import {ValueList} from './ValueList';
 import {SearchIndexResult} from './hooks/useSearch';
+import {getInputSchemaFromViewParent, ViewParent} from '../../utils/fields';
 
 export interface AddMenuProps {
   rootQuery: ASTQuery;
-  view: ASTView | ASTQuery;
+  view: ViewParent;
 }
 
 export function AddMenu({rootQuery, view}: AddMenuProps) {
   const [open, setOpen] = useState(false);
   const {setQuery} = useContext(QueryEditorContext);
   const [search, setSearch] = useState('');
-
-  const segment = view.getOrAddDefaultSegment();
 
   return (
     <Popover.Root
@@ -77,10 +76,11 @@ export function AddMenu({rootQuery, view}: AddMenuProps) {
           {search ? (
             <div style={{overflow: 'auto', overflowY: 'scroll', flex: 1}}>
               <FieldList
-                segment={segment}
-                fields={segment.getInputSchema().fields}
+                view={view}
+                fields={getInputSchemaFromViewParent(view).fields}
                 types={['dimension', 'measure', 'view']}
                 onClick={function (field: FieldInfo, path: string[]): void {
+                  const segment = view.getOrAddDefaultSegment();
                   if (field.kind === 'dimension') {
                     segment.addGroupBy(field.name, path);
                     if (!segmentHasLimit(segment)) {
@@ -106,6 +106,7 @@ export function AddMenu({rootQuery, view}: AddMenuProps) {
                 onClick={(value: SearchIndexResult) => {
                   const path = value.fieldName.split('.'); // TODO handle escaped .s
                   const name = path.pop() as string;
+                  const segment = view.getOrAddDefaultSegment();
                   segment.addWhere(name, path, {
                     kind: 'string',
                     parsed: {operator: '=', values: [value.fieldValue ?? '∅']},
@@ -116,14 +117,14 @@ export function AddMenu({rootQuery, view}: AddMenuProps) {
             </div>
           ) : (
             <>
-              <AddGroupBy rootQuery={rootQuery} segment={segment} />
-              <AddAggregate rootQuery={rootQuery} segment={segment} />
-              <AddWhere rootQuery={rootQuery} segment={segment} />
-              <AddView rootQuery={rootQuery} view={view} segment={segment} />
+              <AddGroupBy rootQuery={rootQuery} view={view} />
+              <AddAggregate rootQuery={rootQuery} view={view} />
+              <AddWhere rootQuery={rootQuery} view={view} />
+              <AddView rootQuery={rootQuery} view={view} />
               <Divider />
-              <AddLimit rootQuery={rootQuery} segment={segment} />
-              <AddOrderBy rootQuery={rootQuery} segment={segment} />
-              <AddEmptyNest rootQuery={rootQuery} segment={segment} />
+              <AddLimit rootQuery={rootQuery} view={view} />
+              <AddOrderBy rootQuery={rootQuery} view={view} />
+              <AddEmptyNest rootQuery={rootQuery} view={view} />
             </>
           )}
         </Popover.Content>

--- a/src/components/QueryPanel/AddMenu/AddWhere.tsx
+++ b/src/components/QueryPanel/AddMenu/AddWhere.tsx
@@ -7,27 +7,25 @@
 
 import * as React from 'react';
 import {useContext} from 'react';
-import {
-  ASTQuery,
-  ASTSegmentViewDefinition,
-} from '@malloydata/malloy-query-builder';
+import {ASTQuery} from '@malloydata/malloy-query-builder';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import {AddFieldItem} from './AddFieldItem';
+import {getInputSchemaFromViewParent, ViewParent} from '../../utils/fields';
 
 export interface AddWhereProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
 }
 
-export function AddWhere({rootQuery, segment}: AddWhereProps) {
+export function AddWhere({rootQuery, view}: AddWhereProps) {
   const {setQuery} = useContext(QueryEditorContext);
-  const {fields} = segment.getInputSchema();
+  const {fields} = getInputSchemaFromViewParent(view);
 
   return (
     <AddFieldItem
       label="Add filter"
       icon="filter"
-      segment={segment}
+      view={view}
       fields={fields}
       types={['measure', 'dimension']}
       filter={(_segment, field) =>
@@ -35,6 +33,7 @@ export function AddWhere({rootQuery, segment}: AddWhereProps) {
         FILTERABLE_TYPES.has(field.type.kind)
       }
       onClick={(field, path) => {
+        const segment = view.getOrAddDefaultSegment();
         if (field.kind === 'dimension' || field.kind === 'measure') {
           if (field.type.kind === 'string_type') {
             segment.addWhere(field.name, path, '-null');

--- a/src/components/QueryPanel/AddMenu/FieldList.tsx
+++ b/src/components/QueryPanel/AddMenu/FieldList.tsx
@@ -10,8 +10,7 @@ import {useMemo} from 'react';
 import * as Malloy from '@malloydata/malloy-interfaces';
 import stylex from '@stylexjs/stylex';
 import {addMenuStyles} from './styles';
-import {sortFieldInfos} from '../../utils/fields';
-import {ASTSegmentViewDefinition} from '@malloydata/malloy-query-builder';
+import {sortFieldInfos, ViewParent} from '../../utils/fields';
 import FieldToken from '../../FieldToken';
 import {FieldHoverCard} from '../../FieldHoverCard';
 
@@ -26,20 +25,20 @@ interface Group {
 }
 
 export interface FieldListProps {
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
   fields: Malloy.FieldInfo[];
   search: string;
   onClick: (field: Malloy.FieldInfo, path: string[]) => void;
   types: Array<'dimension' | 'measure' | 'view'>;
   filter?: (
-    segment: ASTSegmentViewDefinition,
+    view: ViewParent,
     field: Malloy.FieldInfo,
     path: string[]
   ) => boolean;
 }
 
 export function FieldList({
-  segment,
+  view,
   fields,
   onClick,
   search,
@@ -60,7 +59,7 @@ export function FieldList({
         .filter(
           field => field.name.includes(search) && types.includes(field.kind)
         )
-        .filter(field => (filter ? filter(segment, field, path) : true));
+        .filter(field => (filter ? filter(view, field, path) : true));
 
       const joins = fields.filter(field => field.kind === 'join');
 
@@ -85,7 +84,7 @@ export function FieldList({
     buildGroups(types, [], 'Source', fields);
 
     return groups;
-  }, [fields, filter, search, segment, types]);
+  }, [fields, filter, search, view, types]);
 
   return (
     <div>
@@ -115,6 +114,7 @@ export function FieldList({
                     side: 'right',
                     align: 'start',
                     sideOffset: 4,
+                    alignOffset: 24,
                   }}
                 />
               </div>

--- a/src/components/QueryPanel/AddMenu/FieldMenu.tsx
+++ b/src/components/QueryPanel/AddMenu/FieldMenu.tsx
@@ -8,17 +8,17 @@
 import * as React from 'react';
 import {useState} from 'react';
 import * as Malloy from '@malloydata/malloy-interfaces';
-import {ASTSegmentViewDefinition} from '@malloydata/malloy-query-builder';
 import stylex from '@stylexjs/stylex';
 import {Divider, TextInput} from '../../primitives';
 import {addMenuStyles} from './styles';
 import {FieldList} from './FieldList';
+import {ViewParent} from '../../utils/fields';
 export interface FieldMenuProps {
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
   fields: Array<Malloy.FieldInfo>;
   types: Array<'dimension' | 'measure' | 'view'>;
   filter?: (
-    segment: ASTSegmentViewDefinition,
+    view: ViewParent,
     field: Malloy.FieldInfo,
     path: string[]
   ) => boolean;
@@ -26,7 +26,7 @@ export interface FieldMenuProps {
 }
 
 export function FieldMenu({
-  segment,
+  view,
   fields,
   types,
   filter,
@@ -47,7 +47,7 @@ export function FieldMenu({
       <Divider />
       <div style={{overflow: 'auto', overflowY: 'scroll', flex: 1}}>
         <FieldList
-          segment={segment}
+          view={view}
           fields={fields}
           search={search}
           types={types}

--- a/src/components/QueryPanel/Operations.tsx
+++ b/src/components/QueryPanel/Operations.tsx
@@ -13,6 +13,7 @@ import {
   ASTNestViewOperation,
   ASTOrderByViewOperation,
   ASTQuery,
+  ASTSegmentViewDefinition,
   ASTViewDefinition,
   ASTWhereViewOperation,
 } from '@malloydata/malloy-query-builder';
@@ -44,7 +45,12 @@ export function Operations({rootQuery, viewDef}: OperationsProps) {
   const nests: ASTNestViewOperation[] = [];
   let limit: ASTLimitViewOperation | undefined;
 
-  const segment = viewDef.getOrAddDefaultSegment();
+  if (!(viewDef instanceof ASTSegmentViewDefinition)) {
+    return null;
+  }
+
+  const segment = viewDef;
+  const view = viewDef.parent.as.View();
 
   segment.operations.items.forEach(operation => {
     if (operation instanceof ASTGroupByViewOperation) {
@@ -66,26 +72,18 @@ export function Operations({rootQuery, viewDef}: OperationsProps) {
     <div {...stylex.props(operationStyles.indent)}>
       <GroupByOperations
         rootQuery={rootQuery}
-        segment={segment}
+        view={view}
         groupBys={groupBys}
       />
       <AggregateOperations
         rootQuery={rootQuery}
-        segment={segment}
+        view={view}
         aggregates={aggregates}
       />
-      <WhereOperations
-        rootQuery={rootQuery}
-        segment={segment}
-        wheres={wheres}
-      />
-      <OrderByOperations
-        rootQuery={rootQuery}
-        segment={segment}
-        orderBys={orderBys}
-      />
-      <NestOperations rootQuery={rootQuery} segment={segment} nests={nests} />
-      <LimitOperation rootQuery={rootQuery} segment={segment} limit={limit} />
+      <WhereOperations rootQuery={rootQuery} wheres={wheres} />
+      <OrderByOperations rootQuery={rootQuery} orderBys={orderBys} />
+      <NestOperations rootQuery={rootQuery} nests={nests} />
+      <LimitOperation rootQuery={rootQuery} limit={limit} />
     </div>
   );
 }

--- a/src/components/QueryPanel/Operations.tsx
+++ b/src/components/QueryPanel/Operations.tsx
@@ -24,6 +24,7 @@ import {AggregateOperations} from './operations/AggregateOperations';
 import {OrderByOperations} from './operations/OrderByOperations';
 import {NestOperations} from './operations/NestOperation';
 import stylex from '@stylexjs/stylex';
+import {ViewParent} from '../utils/fields';
 
 const operationStyles = stylex.create({
   indent: {
@@ -34,10 +35,11 @@ const operationStyles = stylex.create({
 
 export interface OperationsProps {
   rootQuery: ASTQuery;
+  view: ViewParent;
   viewDef: ASTViewDefinition;
 }
 
-export function Operations({rootQuery, viewDef}: OperationsProps) {
+export function Operations({rootQuery, view, viewDef}: OperationsProps) {
   const groupBys: ASTGroupByViewOperation[] = [];
   const aggregates: ASTAggregateViewOperation[] = [];
   const wheres: ASTWhereViewOperation[] = [];
@@ -50,7 +52,6 @@ export function Operations({rootQuery, viewDef}: OperationsProps) {
   }
 
   const segment = viewDef;
-  const view = viewDef.parent.as.View();
 
   segment.operations.items.forEach(operation => {
     if (operation instanceof ASTGroupByViewOperation) {

--- a/src/components/QueryPanel/Query.tsx
+++ b/src/components/QueryPanel/Query.tsx
@@ -55,7 +55,9 @@ export function Query({rootQuery, query, setQuery}: QueryProps) {
               <></>
             )}
           </DropdownMenu>
-          <AddMenu rootQuery={rootQuery} view={query} />
+          {query.definition instanceof ASTArrowQueryDefinition ? (
+            <AddMenu rootQuery={rootQuery} view={query.definition} />
+          ) : null}
         </>
       }
       collapsedControls={<VisualizationIcon view={query} />}

--- a/src/components/QueryPanel/Query.tsx
+++ b/src/components/QueryPanel/Query.tsx
@@ -69,6 +69,7 @@ export function Query({rootQuery, query, setQuery}: QueryProps) {
           )}
           <ViewDefinition
             rootQuery={rootQuery}
+            view={query.definition}
             viewDef={query.definition.view}
           />
         </div>

--- a/src/components/QueryPanel/View.tsx
+++ b/src/components/QueryPanel/View.tsx
@@ -19,7 +19,11 @@ export function View({rootQuery, view}: ViewProps) {
   return (
     <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
       <Visualization rootQuery={rootQuery} view={view} />
-      <ViewDefinition rootQuery={rootQuery} viewDef={view.definition} />
+      <ViewDefinition
+        rootQuery={rootQuery}
+        view={view}
+        viewDef={view.definition}
+      />
     </div>
   );
 }

--- a/src/components/QueryPanel/ViewDefinition.tsx
+++ b/src/components/QueryPanel/ViewDefinition.tsx
@@ -20,24 +20,40 @@ import {Button, Icon, IconType} from '../primitives';
 import ViewAttributeTable from '../ResultPanel/ViewAttributeTable';
 import {JSX, useState} from 'react';
 import {textColors} from '../primitives/colors.stylex';
+import {ViewParent} from '../utils/fields';
 
 export interface ViewProps {
   rootQuery: ASTQuery;
+  view: ViewParent;
   viewDef: ASTViewDefinition;
 }
 
-export function ViewDefinition({rootQuery, viewDef}: ViewProps) {
+export function ViewDefinition({rootQuery, view, viewDef}: ViewProps) {
   if (viewDef instanceof ASTArrowViewDefinition) {
-    return <ViewDefinition rootQuery={rootQuery} viewDef={viewDef.view} />;
+    return (
+      <ViewDefinition
+        rootQuery={rootQuery}
+        view={view}
+        viewDef={viewDef.view}
+      />
+    );
   } else if (viewDef instanceof ASTRefinementViewDefinition) {
     return (
       <div>
-        <ViewDefinition rootQuery={rootQuery} viewDef={viewDef.base} />
-        <ViewDefinition rootQuery={rootQuery} viewDef={viewDef.refinement} />
+        <ViewDefinition
+          rootQuery={rootQuery}
+          view={view}
+          viewDef={viewDef.base}
+        />
+        <ViewDefinition
+          rootQuery={rootQuery}
+          view={view}
+          viewDef={viewDef.refinement}
+        />
       </div>
     );
   } else if (viewDef instanceof ASTSegmentViewDefinition) {
-    return <Operations rootQuery={rootQuery} viewDef={viewDef} />;
+    return <Operations rootQuery={rootQuery} view={view} viewDef={viewDef} />;
   } else {
     return <CollapsingView rootQuery={rootQuery} viewDef={viewDef} />;
   }

--- a/src/components/QueryPanel/operations/AggregateOperations.tsx
+++ b/src/components/QueryPanel/operations/AggregateOperations.tsx
@@ -13,7 +13,6 @@ import {styles} from '../../styles';
 import {
   ASTAggregateViewOperation,
   ASTQuery,
-  ASTSegmentViewDefinition,
 } from '@malloydata/malloy-query-builder';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import {hoverStyles} from './hover.stylex';
@@ -21,16 +20,17 @@ import {ClearButton} from './ClearButton';
 import {OperationActionTitle} from './OperationActionTitle';
 import {FieldHover} from '../FieldHover';
 import FieldToken from '../../FieldToken';
+import {getInputSchemaFromViewParent, ViewParent} from '../../utils/fields';
 
 export interface AggregateOperationsProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
   aggregates: ASTAggregateViewOperation[];
 }
 
 export function AggregateOperations({
   rootQuery,
-  segment,
+  view,
   aggregates,
 }: AggregateOperationsProps) {
   const {setQuery} = useContext(QueryEditorContext);
@@ -38,7 +38,7 @@ export function AggregateOperations({
     return null;
   }
 
-  const {fields} = segment.getInputSchema();
+  const {fields} = getInputSchemaFromViewParent(view);
 
   return (
     <div>
@@ -46,10 +46,11 @@ export function AggregateOperations({
         title="aggregate"
         actionTitle="Add aggregate"
         rootQuery={rootQuery}
-        segment={segment}
+        view={view}
         fields={fields}
         types={['measure']}
         onClick={(field: Malloy.FieldInfo, path: string[]) => {
+          const segment = view.getOrAddDefaultSegment();
           segment.addAggregate(field.name, path);
           setQuery?.(rootQuery.build());
         }}

--- a/src/components/QueryPanel/operations/GroupByOperations.tsx
+++ b/src/components/QueryPanel/operations/GroupByOperations.tsx
@@ -13,7 +13,6 @@ import {styles as commonStyles} from '../../styles';
 import {
   ASTGroupByViewOperation,
   ASTQuery,
-  ASTSegmentViewDefinition,
 } from '@malloydata/malloy-query-builder';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import {hoverStyles} from './hover.stylex';
@@ -22,16 +21,17 @@ import {addGroupBy} from '../../utils/segment';
 import {OperationActionTitle} from './OperationActionTitle';
 import {FieldHover} from '../FieldHover';
 import FieldToken from '../../FieldToken';
+import {getInputSchemaFromViewParent, ViewParent} from '../../utils/fields';
 
 export interface GroupByOperationsProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
   groupBys: ASTGroupByViewOperation[];
 }
 
 export function GroupByOperations({
   rootQuery,
-  segment,
+  view,
   groupBys,
 }: GroupByOperationsProps) {
   const {setQuery} = useContext(QueryEditorContext);
@@ -39,7 +39,7 @@ export function GroupByOperations({
     return null;
   }
 
-  const {fields} = segment.getInputSchema();
+  const {fields} = getInputSchemaFromViewParent(view);
 
   return (
     <div>
@@ -47,10 +47,11 @@ export function GroupByOperations({
         title="group by"
         actionTitle="Add group by"
         rootQuery={rootQuery}
-        segment={segment}
+        view={view}
         fields={fields}
         types={['dimension']}
         onClick={(field: Malloy.FieldInfo, path: string[]) => {
+          const segment = view.getOrAddDefaultSegment();
           addGroupBy(rootQuery, segment, field, path, setQuery);
         }}
       />

--- a/src/components/QueryPanel/operations/LimitOperation.tsx
+++ b/src/components/QueryPanel/operations/LimitOperation.tsx
@@ -10,7 +10,6 @@ import {useContext} from 'react';
 import {
   ASTLimitViewOperation,
   ASTQuery,
-  ASTSegmentViewDefinition,
 } from '@malloydata/malloy-query-builder';
 import stylex from '@stylexjs/stylex';
 import {styles} from '../../styles';
@@ -21,7 +20,6 @@ import {ClearButton} from './ClearButton';
 
 export interface LimitOperationProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
   limit: ASTLimitViewOperation | undefined;
 }
 

--- a/src/components/QueryPanel/operations/NestOperation.tsx
+++ b/src/components/QueryPanel/operations/NestOperation.tsx
@@ -6,11 +6,7 @@
  */
 
 import * as React from 'react';
-import {
-  ASTNestViewOperation,
-  ASTQuery,
-  ASTSegmentViewDefinition,
-} from '@malloydata/malloy-query-builder';
+import {ASTNestViewOperation, ASTQuery} from '@malloydata/malloy-query-builder';
 import stylex from '@stylexjs/stylex';
 import {styles} from '../../styles';
 import {View} from '../View';
@@ -23,7 +19,6 @@ import {VisualizationIcon} from '../VisualizationIcon';
 
 export interface NestOperationsProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
   nests: ASTNestViewOperation[];
 }
 

--- a/src/components/QueryPanel/operations/OperationActionTitle.tsx
+++ b/src/components/QueryPanel/operations/OperationActionTitle.tsx
@@ -8,18 +8,16 @@
 import * as React from 'react';
 import * as Popover from '@radix-ui/react-popover';
 import * as Malloy from '@malloydata/malloy-interfaces';
-import {
-  ASTQuery,
-  ASTSegmentViewDefinition,
-} from '@malloydata/malloy-query-builder';
+import {ASTQuery} from '@malloydata/malloy-query-builder';
 import {hoverStyles} from './hover.stylex';
 import {styles as commonStyles} from '../../styles';
 import {FieldMenu} from '../AddMenu/FieldMenu';
 import stylex from '@stylexjs/stylex';
+import {viewParentDoesNotHaveField, ViewParent} from '../../utils/fields';
 
 export interface OperationActionTitleProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
+  view: ViewParent;
   title: string;
   actionTitle: string;
   fields: Malloy.FieldInfo[];
@@ -29,7 +27,7 @@ export interface OperationActionTitleProps {
 
 export function OperationActionTitle({
   actionTitle,
-  segment,
+  view,
   fields,
   title,
   types,
@@ -50,12 +48,10 @@ export function OperationActionTitle({
               alignOffset={-16}
             >
               <FieldMenu
-                segment={segment}
+                view={view}
                 fields={fields}
                 types={types}
-                filter={(segment, field, path) =>
-                  !segment.hasField(field.name, path)
-                }
+                filter={viewParentDoesNotHaveField}
                 onClick={onClick}
               />
             </Popover.PopoverContent>

--- a/src/components/QueryPanel/operations/OrderByOperations.tsx
+++ b/src/components/QueryPanel/operations/OrderByOperations.tsx
@@ -10,7 +10,6 @@ import {useContext} from 'react';
 import {
   ASTOrderByViewOperation,
   ASTQuery,
-  ASTSegmentViewDefinition,
 } from '@malloydata/malloy-query-builder';
 import stylex from '@stylexjs/stylex';
 import {styles} from '../../styles';
@@ -22,7 +21,6 @@ import {ClearButton} from './ClearButton';
 
 export interface OrderByOperationsProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
   orderBys: ASTOrderByViewOperation[];
 }
 

--- a/src/components/QueryPanel/operations/WhereOperations.tsx
+++ b/src/components/QueryPanel/operations/WhereOperations.tsx
@@ -9,7 +9,6 @@ import * as React from 'react';
 import {useContext} from 'react';
 import {
   ASTQuery,
-  ASTSegmentViewDefinition,
   ASTWhereViewOperation,
   ParsedFilter,
 } from '@malloydata/malloy-query-builder';
@@ -27,7 +26,6 @@ import {DateTimeFilterToken} from '../../filters/DateTimeFilterToken';
 
 export interface WhereOperationsProps {
   rootQuery: ASTQuery;
-  segment: ASTSegmentViewDefinition;
   wheres: ASTWhereViewOperation[];
 }
 

--- a/src/components/utils/fields.ts
+++ b/src/components/utils/fields.ts
@@ -6,6 +6,13 @@
  */
 
 import * as Malloy from '@malloydata/malloy-interfaces';
+import {
+  ASTArrowQueryDefinition,
+  ASTSegmentViewDefinition,
+  ASTView,
+} from '@malloydata/malloy-query-builder';
+
+export type ViewParent = ASTArrowQueryDefinition | ASTView;
 
 /**
  *
@@ -49,4 +56,37 @@ export function isIndexView(field: Malloy.FieldInfoWithView) {
   ]);
   // Complete overlap of fields
   return allFields.size === INDEX_FIELDS.length;
+}
+
+export function getViewDefinition(parent: ViewParent) {
+  return parent instanceof ASTArrowQueryDefinition
+    ? parent.view
+    : parent.definition;
+}
+
+export function getInputSchemaFromViewParent(
+  parent: ViewParent
+): Malloy.Schema {
+  const definition = getViewDefinition(parent);
+  return definition.getInputSchema();
+}
+
+export function viewParentHasField(
+  parent: ViewParent,
+  field: Malloy.FieldInfo,
+  path: string[]
+) {
+  const definition = getViewDefinition(parent);
+  if (definition instanceof ASTSegmentViewDefinition) {
+    return definition.hasField(field.name, path);
+  }
+  return false;
+}
+
+export function viewParentDoesNotHaveField(
+  parent: ViewParent,
+  field: Malloy.FieldInfo,
+  path: string[]
+) {
+  return !viewParentHasField(parent, field, path);
 }

--- a/src/components/utils/segment.ts
+++ b/src/components/utils/segment.ts
@@ -4,6 +4,7 @@ import {
   ASTNestViewOperation,
   ASTOrderByViewOperation,
   ASTQuery,
+  ASTRefinementViewDefinition,
   ASTSegmentViewDefinition,
 } from '@malloydata/malloy-query-builder';
 import {ViewParent, getViewDefinition} from './fields';
@@ -67,7 +68,10 @@ export function getSegmentIfPresent(
   parent: ViewParent
 ): ASTSegmentViewDefinition | undefined {
   const definition = getViewDefinition(parent);
-  if (definition instanceof ASTSegmentViewDefinition) {
+  if (
+    definition instanceof ASTSegmentViewDefinition ||
+    definition instanceof ASTRefinementViewDefinition
+  ) {
     return definition.getOrAddDefaultSegment();
   }
   return undefined;

--- a/src/components/utils/segment.ts
+++ b/src/components/utils/segment.ts
@@ -68,11 +68,12 @@ export function getSegmentIfPresent(
   parent: ViewParent
 ): ASTSegmentViewDefinition | undefined {
   const definition = getViewDefinition(parent);
-  if (
-    definition instanceof ASTSegmentViewDefinition ||
-    definition instanceof ASTRefinementViewDefinition
-  ) {
-    return definition.getOrAddDefaultSegment();
+  if (definition instanceof ASTSegmentViewDefinition) {
+    return definition;
+  } else if (definition instanceof ASTRefinementViewDefinition) {
+    if (definition.refinement instanceof ASTSegmentViewDefinition) {
+      return definition.refinement;
+    }
   }
   return undefined;
 }

--- a/src/components/utils/segment.ts
+++ b/src/components/utils/segment.ts
@@ -6,6 +6,7 @@ import {
   ASTQuery,
   ASTSegmentViewDefinition,
 } from '@malloydata/malloy-query-builder';
+import {ViewParent, getViewDefinition} from './fields';
 
 export function segmentHasLimit(segment: ASTSegmentViewDefinition) {
   return (
@@ -60,4 +61,14 @@ export function addGroupBy(
   }
   segment.addOrderBy(field.name);
   setQuery?.(rootQuery.build());
+}
+
+export function getSegmentIfPresent(
+  parent: ViewParent
+): ASTSegmentViewDefinition | undefined {
+  const definition = getViewDefinition(parent);
+  if (definition instanceof ASTSegmentViewDefinition) {
+    return definition.getOrAddDefaultSegment();
+  }
+  return undefined;
 }


### PR DESCRIPTION
Calling `getOrAddDefaultSegment()` to interrogate a query can cause a mutation, so don't unless you mean to. This meant pushing the view or query object down instead of the segment.