### PR TITLE
Fix menu glitches by ensuring triggers remain visible as long as their menus do 

### DIFF
--- a/src/components/QueryPanel/operations/OperationActionTitle.tsx
+++ b/src/components/QueryPanel/operations/OperationActionTitle.tsx
@@ -33,11 +33,17 @@ export function OperationActionTitle({
   types,
   onClick,
 }: OperationActionTitleProps) {
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   return (
     <div {...stylex.props(commonStyles.title, hoverStyles.main)}>
       <div>{title}</div>
-      <div {...stylex.props(hoverStyles.hoverActions)}>
-        <Popover.Root>
+      <div
+        {...stylex.props(
+          hoverStyles.hoverActions,
+          isMenuOpen ? hoverStyles.hoverOpen : undefined
+        )}
+      >
+        <Popover.Root onOpenChange={setIsMenuOpen}>
           <Popover.Trigger asChild>
             <div {...stylex.props(styles.action)}>{actionTitle}</div>
           </Popover.Trigger>

--- a/src/components/QueryPanel/operations/hover.stylex.ts
+++ b/src/components/QueryPanel/operations/hover.stylex.ts
@@ -21,4 +21,7 @@ export const hoverStyles = stylex.create({
     display: hoverActionsVars.display,
     flexShrink: 0,
   },
+  hoverOpen: {
+    display: 'inline-flex',
+  },
 });


### PR DESCRIPTION
Hovering over a heading in the Query panel would show an "Add group by...' button (or whichever is appropriate for that heading). Exiting the hover would hide the button, which also happened to be the anchor for the menu. This caused lots of problems.

Now we don't hide the anchor while the menu is open, so it won't jump around or flicker.

<img width="807" alt="image" src="https://github.com/user-attachments/assets/2fc00b97-ffa9-478b-952c-41b2c30a5c7d" />
