### PR TITLE
Default blank nested queries to be expanded

### DIFF
--- a/src/components/QueryPanel/operations/NestOperation.tsx
+++ b/src/components/QueryPanel/operations/NestOperation.tsx
@@ -40,12 +40,18 @@ export function NestOperations({rootQuery, nests}: NestOperationsProps) {
   return (
     <div {...stylex.props(styles.tokenContainer)}>
       {nests.map(nest => {
+        // New blank nested queries should default to their open mode to make
+        // it simpler to add content into.
+        const defaultOpen =
+          nest.view.definition.node.kind === 'segment' &&
+          nest.view.definition.node.operations.length === 0;
+
         return (
           <div key={nest.name} {...stylex.props(viewStyles.indent)}>
             <CollapsiblePanel
               title={nest.name}
               icon="nest"
-              defaultOpen={false}
+              defaultOpen={defaultOpen}
               controls={
                 <>
                   <DropdownMenu


### PR DESCRIPTION
Right now, if you add a blank nested query, you have to manually expand it before adding content to it, because the action menu items are not visible while it is collapsed. Default it to expanded, because typically the nest action the user will want to take is interacting with it.

<img width="236" alt="image" src="https://github.com/user-attachments/assets/90534c42-4158-4e8e-aae8-f2ab5d68bce7" />
