### PR TITLE
Remove the logic that adds a 1000 limit along with a group_by

### DIFF
--- a/src/components/QueryPanel/AddMenu/AddMenu.tsx
+++ b/src/components/QueryPanel/AddMenu/AddMenu.tsx
@@ -22,7 +22,7 @@ import {AddView} from './AddView';
 import {FieldInfo} from '@malloydata/malloy-interfaces';
 import {QueryEditorContext} from '../../../contexts/QueryEditorContext';
 import {FieldList} from './FieldList';
-import {segmentHasLimit, segmentNestNo} from '../../utils/segment';
+import {segmentNestNo} from '../../utils/segment';
 import {ValueList} from './ValueList';
 import {SearchIndexResult} from './hooks/useSearch';
 import {getInputSchemaFromViewParent, ViewParent} from '../../utils/fields';
@@ -83,9 +83,6 @@ export function AddMenu({rootQuery, view}: AddMenuProps) {
                   const segment = view.getOrAddDefaultSegment();
                   if (field.kind === 'dimension') {
                     segment.addGroupBy(field.name, path);
-                    if (!segmentHasLimit(segment)) {
-                      segment.setLimit(1000);
-                    }
                   } else if (field.kind === 'measure') {
                     segment.addAggregate(field.name, path);
                   } else {

--- a/src/components/utils/segment.ts
+++ b/src/components/utils/segment.ts
@@ -57,9 +57,6 @@ export function addGroupBy(
   setQuery?: (query: Malloy.Query) => void
 ): void {
   segment.addGroupBy(field.name, path);
-  if (!segmentHasLimit(segment)) {
-    segment.setLimit(1000);
-  }
   setQuery?.(rootQuery.build());
 }
 


### PR DESCRIPTION
Since we should be applying and propagating default limits now, it doesn't make a lot of sense to add a `limit: 1000` (but only on group_by).

This also brings consistency to the different "add group by" flows, some of which do not include this logic today.

Followup to https://github.com/malloydata/malloy-explorer/pull/139