### PR TITLE
Remove placeholder hovertext

### DIFF
--- a/src/components/FieldHoverCard.tsx
+++ b/src/components/FieldHoverCard.tsx
@@ -36,7 +36,7 @@ export function FieldHoverCard({field, path}: FieldHoverCardProps) {
   const descriptionAnnotation = getDescriptionAnnotation(
     field.annotations ?? []
   );
-  const description = descriptionAnnotation ?? 'This is a ' + field.kind + '.';
+  const description = descriptionAnnotation ?? '';
 
   let details = null;
   if (field.kind === 'view') {


### PR DESCRIPTION
Removes the "This is a dimension" content from the hover card when the description could not be otherwise found.

<img width="511" alt="image" src="https://github.com/user-attachments/assets/8b8d5ad1-f8bf-4d58-8824-4731f9f4ecfa" />
