### PR TITLE
fix: renderer should virtualize

### DIFF
--- a/src/components/ResultPanel/ResultDisplay.tsx
+++ b/src/components/ResultPanel/ResultDisplay.tsx
@@ -19,6 +19,8 @@ import {
 } from './SubmittedQuery';
 import * as render from '@malloydata/render';
 import DOMElement from '../primitives/DOMElement';
+// CSS file needed because stylex doesn't support ::part selector
+import './result_display.css';
 
 import '@malloydata/render/webcomponent';
 import {Variant} from '../primitives/Banner';
@@ -85,7 +87,7 @@ function ResponseDisplay({response}: ResponseProps) {
   }
 
   return (
-    <div>
+    <div {...stylex.props(styles.resultContainer)}>
       {response?.runInfo && <RunInfoHover runInfo={response.runInfo} />}
       {messageComponent}
       {response?.result && <RenderedResult result={response.result} />}
@@ -174,20 +176,21 @@ function RenderedResult({result}: RenderedResultProps) {
     };
   }, [result]);
 
+  if (!rendering)
+    return (
+      html && (
+        <DOMElement className="malloy-render_result-wrapper" element={html} />
+      )
+    );
+
   return (
     <ScrollableArea>
-      {rendering ? (
-        <div {...stylex.props(styles.renderingSpinnerContainer)}>
-          <div {...stylex.props(styles.renderingSpinner)}>
-            <Spinner size="large" />
-            <div {...stylex.props(fontStyles.emphasized)}>Rendering...</div>
-          </div>
+      <div {...stylex.props(styles.renderingSpinnerContainer)}>
+        <div {...stylex.props(styles.renderingSpinner)}>
+          <Spinner size="large" />
+          <div {...stylex.props(fontStyles.emphasized)}>Rendering...</div>
         </div>
-      ) : (
-        <div {...stylex.props(styles.resultContainer)}>
-          {html && <DOMElement element={html} />}
-        </div>
-      )}
+      </div>
     </ScrollableArea>
   );
 }
@@ -270,7 +273,7 @@ const styles = stylex.create({
     gap: '8px',
   },
   resultContainer: {
-    zIndex: '0',
-    position: 'relative',
+    display: 'grid',
+    height: '100%',
   },
 });

--- a/src/components/ResultPanel/result_display.css
+++ b/src/components/ResultPanel/result_display.css
@@ -1,0 +1,8 @@
+.malloy-render_result-wrapper malloy-render::part(table-container) {
+    width: 100%;   
+}
+
+.malloy-render_result-wrapper {
+    height: 100%;
+    overflow: hidden;
+}

--- a/src/components/primitives/DOMElement.tsx
+++ b/src/components/primitives/DOMElement.tsx
@@ -9,9 +9,15 @@ import * as React from 'react';
 
 interface DOMElementProps {
   element: HTMLElement;
+  className?: string;
+  style?: Record<string, string | number>;
 }
 
-export default function DOMElement({element}: DOMElementProps) {
+export default function DOMElement({
+  element,
+  className,
+  style,
+}: DOMElementProps) {
   const ref = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -21,5 +27,5 @@ export default function DOMElement({element}: DOMElementProps) {
     }
   }, [element]);
 
-  return <div ref={ref}></div>;
+  return <div ref={ref} className={className} style={style}></div>;
 }


### PR DESCRIPTION
The renderer was being rendered in a ScrollArea that was controlling the overflow. In order for row virtualization to work, the renderer has to be the one controlling its scroll container. This PR:

- updates the markup so that renderer is outside of a ScrollArea
- sets ResultDisplay to a CSS grid so the renderer height is constrained to available space instead of growing unbounded
- adds styling for the renderer to fill the width of ResultDisplay container, which makes for a better scrolling experience

Note that I had to import a css file instead of using stylex for adding the width to the malloy-render component, because I could not get stylex to support the `::part` selector. The build would fail with error "pseudo-class not recognized" when I tried using it in a style object.

Demo

https://github.com/user-attachments/assets/b5f87480-63fb-4c2b-8adf-50ea51f0dc6a

