### PR TITLE
Use our date picker for parameters

### DIFF
--- a/dev/Source.tsx
+++ b/dev/Source.tsx
@@ -18,7 +18,11 @@ const App = () => {
     <React.StrictMode>
       <MalloyExplorerProvider source={source}>
         <div style={{display: 'flex', height: '100%'}}>
-          <SourcePanel source={source} setQuery={() => {}} />
+          <SourcePanel
+            onRefresh={() => {
+              window.alert('Refresh!');
+            }}
+          />
         </div>
       </MalloyExplorerProvider>
     </React.StrictMode>

--- a/dev/sample_models/example_model.ts
+++ b/dev/sample_models/example_model.ts
@@ -551,6 +551,30 @@ export const modelInfo: Malloy.ModelInfo = {
           type: {kind: 'string_type'},
           default_value: {kind: 'string_literal', string_value: 'AA'},
         },
+        {
+          name: 'Date',
+          type: {kind: 'date_type'},
+          default_value: {
+            kind: 'date_literal',
+            date_value: '1980-05-18',
+          },
+        },
+        {
+          name: 'Timestamp',
+          type: {kind: 'timestamp_type'},
+          default_value: {
+            kind: 'timestamp_literal',
+            timestamp_value: '1980-05-18 15:00:00',
+          },
+        },
+        {
+          name: 'Filter',
+          type: {kind: 'filter_expression_type'},
+          default_value: {
+            kind: 'filter_expression_literal',
+            filter_expression_value: '7 days',
+          },
+        },
       ],
       schema: {
         fields: [
@@ -2404,7 +2428,23 @@ export const modelInfo2: Malloy.ModelInfo = {
           type: {kind: 'date_type'},
           default_value: {
             kind: 'date_literal',
-            date_value: '1971-05-19',
+            date_value: '1980-05-18',
+          },
+        },
+        {
+          name: 'Timestamp',
+          type: {kind: 'timestamp_type'},
+          default_value: {
+            kind: 'timestamp_literal',
+            timestamp_value: '1980-05-18 15:00:00',
+          },
+        },
+        {
+          name: 'Filter',
+          type: {kind: 'filter_expression_type'},
+          default_value: {
+            kind: 'filter_expression_literal',
+            filter_expression_value: '7 days',
           },
         },
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@malloydata/malloy-explorer",
-  "version": "0.0.269",
+  "version": "0.0.271",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@malloydata/malloy-explorer",
-      "version": "0.0.269",
+      "version": "0.0.271",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -63,11 +63,11 @@
         "vite-plugin-svgr": "^4.3.0"
       },
       "peerDependencies": {
-        "@malloydata/malloy-filter": ">= 0.0.269",
-        "@malloydata/malloy-interfaces": ">= 0.0.269",
-        "@malloydata/malloy-query-builder": ">= 0.0.269",
-        "@malloydata/malloy-tag": ">= 0.0.269",
-        "@malloydata/render": ">= 0.0.269",
+        "@malloydata/malloy-filter": ">=0.0.271",
+        "@malloydata/malloy-interfaces": ">=0.0.271",
+        "@malloydata/malloy-query-builder": ">=0.0.271",
+        "@malloydata/malloy-tag": ">=0.0.271",
+        "@malloydata/render": ">=0.0.271",
         "react": ">= 19.0.0",
         "react-dom": ">= 19.0.0"
       }
@@ -1936,15 +1936,15 @@
       }
     },
     "node_modules/@malloydata/malloy": {
-      "version": "0.0.269",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.269.tgz",
-      "integrity": "sha512-TZ6ejj0KuERWYToh5e/8Zk7+QjSuZKF9KNqTyBZIrAfHM7MW8eq7C9KiyqdqpJ6Ea7Z9CS4zKmPOoaHG7YddkQ==",
+      "version": "0.0.271",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.271.tgz",
+      "integrity": "sha512-shwc9esH14eTGtHDzRK1V06XLd8Fb7wD5EXc4Y5mY8lDzVzokfaT+evS+a1K9BHNZ6Wvq3X83ZsTilJmIp66cA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@malloydata/malloy-filter": "^0.0.269",
-        "@malloydata/malloy-interfaces": "^0.0.269",
-        "@malloydata/malloy-tag": "^0.0.269",
+        "@malloydata/malloy-filter": "^0.0.271",
+        "@malloydata/malloy-interfaces": "^0.0.271",
+        "@malloydata/malloy-tag": "^0.0.271",
         "antlr4ts": "^0.5.0-alpha.4",
         "assert": "^2.0.0",
         "jaro-winkler": "^0.2.8",
@@ -1958,9 +1958,9 @@
       }
     },
     "node_modules/@malloydata/malloy-filter": {
-      "version": "0.0.269",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy-filter/-/malloy-filter-0.0.269.tgz",
-      "integrity": "sha512-p1J82ow4rABkpXeygFG7Atf1fEDJWnjm61oXXIzSpvPcvxlOxUA/GtGnU27fjmkhEncXTTRtjsWseTJMyY9ISg==",
+      "version": "0.0.271",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy-filter/-/malloy-filter-0.0.271.tgz",
+      "integrity": "sha512-DHl5kIMJTc44jddl9cOI9JAGeK7vOJzTBUKM+Q0WVMjg1wC4jwU36uJFiYKur3VcQ5GpP4yEglbdr8zAIP8NaA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1974,9 +1974,9 @@
       }
     },
     "node_modules/@malloydata/malloy-interfaces": {
-      "version": "0.0.269",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy-interfaces/-/malloy-interfaces-0.0.269.tgz",
-      "integrity": "sha512-Z5rN3udVNTCQEynP9lh5/sacMRwUdyGdukfraNFAk0in1QXjnAcVvNOlKqn6pn8SFsS/iVSjTNyhysxUwlK7EQ==",
+      "version": "0.0.271",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy-interfaces/-/malloy-interfaces-0.0.271.tgz",
+      "integrity": "sha512-3/LLjt/uEjg8ZF1EADyGLl4fZ7qOhGUUJSysragaCi8IsTzR4ARx4x1K6u920SmcN/iA5Iuj/50zG2TRybgsQg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1987,24 +1987,24 @@
       }
     },
     "node_modules/@malloydata/malloy-query-builder": {
-      "version": "0.0.269",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy-query-builder/-/malloy-query-builder-0.0.269.tgz",
-      "integrity": "sha512-SWazRx5BzKbwVfTagVUXkGn2+fxM9PW7/GJb8bN1AC0x8HrIcxecUOwKQ2AFFtgMDwJurAtyXAgRNh+njXBiYg==",
+      "version": "0.0.271",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy-query-builder/-/malloy-query-builder-0.0.271.tgz",
+      "integrity": "sha512-BTQzrKCldLnUZkTqD+to1w4dFF1Lq7qZHu1JWTYAo1OzjrpCKYDBdGq8S4DNO/EUD0W4N2MZa+WjkaLu0oDp0A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@malloydata/malloy-filter": "^0.0.269",
-        "@malloydata/malloy-interfaces": "^0.0.269",
-        "@malloydata/malloy-tag": "^0.0.269"
+        "@malloydata/malloy-filter": "^0.0.271",
+        "@malloydata/malloy-interfaces": "^0.0.271",
+        "@malloydata/malloy-tag": "^0.0.271"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@malloydata/malloy-tag": {
-      "version": "0.0.269",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy-tag/-/malloy-tag-0.0.269.tgz",
-      "integrity": "sha512-KCxHFGqzTPWnYsQEuPAvEjMzpa/fsPSEQqH5af8IuNcfr6iHYYa2ynRFv/fTYuGBjLCKyHLN0lDAgCeSXVxt0w==",
+      "version": "0.0.271",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy-tag/-/malloy-tag-0.0.271.tgz",
+      "integrity": "sha512-fxKpPC/lVg3LPRcotZ9dwTGPOIJRl348ujPRo4q1oh157OiKKfWKwrAJK/i2NI6kNWAK5YZMxUWK2D9/X/atJQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2027,15 +2027,15 @@
       }
     },
     "node_modules/@malloydata/render": {
-      "version": "0.0.269",
-      "resolved": "https://registry.npmjs.org/@malloydata/render/-/render-0.0.269.tgz",
-      "integrity": "sha512-ITilMcrWdHx6kD5bJNJo6bX8Fcyb92nr0jQalj2tH76fHZ6A0C9y1BkoIQkKlMqnfI+DQ1rtLio89CwNX1WF8g==",
+      "version": "0.0.271",
+      "resolved": "https://registry.npmjs.org/@malloydata/render/-/render-0.0.271.tgz",
+      "integrity": "sha512-tRjHs/folS962Cg2lK9O8kLU5qpDcUW18fdvITQP3vpfL4p29FsJYKRHkKy4n9JA7QVw8FnanhjAu5/p3rh1wg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@malloydata/malloy": "^0.0.269",
-        "@malloydata/malloy-interfaces": "^0.0.269",
-        "@malloydata/malloy-tag": "^0.0.269",
+        "@malloydata/malloy": "^0.0.271",
+        "@malloydata/malloy-interfaces": "^0.0.271",
+        "@malloydata/malloy-tag": "^0.0.271",
         "@tanstack/solid-virtual": "^3.10.4",
         "component-register": "^0.8.6",
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloydata/malloy-explorer",
-  "version": "0.0.269",
+  "version": "0.0.271",
   "description": "Malloy visual query builder",
   "main": "dist/cjs/index.cjs",
   "types": "dist/types/index.d.ts",
@@ -102,11 +102,11 @@
     "vite-plugin-svgr": "^4.3.0"
   },
   "peerDependencies": {
-    "@malloydata/malloy-filter": ">= 0.0.269",
-    "@malloydata/malloy-interfaces": ">= 0.0.269",
-    "@malloydata/malloy-query-builder": ">= 0.0.269",
-    "@malloydata/malloy-tag": ">= 0.0.269",
-    "@malloydata/render": ">= 0.0.269",
+    "@malloydata/malloy-filter": ">=0.0.271",
+    "@malloydata/malloy-interfaces": ">=0.0.271",
+    "@malloydata/malloy-query-builder": ">=0.0.271",
+    "@malloydata/malloy-tag": ">=0.0.271",
+    "@malloydata/render": ">=0.0.271",
     "react": ">= 19.0.0",
     "react-dom": ">= 19.0.0"
   }

--- a/src/components/DateInput.tsx
+++ b/src/components/DateInput.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react';
 import moment from 'moment';
-import {useEffect, useState} from 'react';
+import {RefObject, useEffect, useState} from 'react';
 import stylex, {StyleXStyles} from '@stylexjs/stylex';
 import {Moment, TemporalUnit} from '@malloydata/malloy-filter';
 
@@ -22,6 +22,7 @@ interface DateInputProps {
   onBlur?: () => void;
   isActive?: boolean;
   customStyle?: StyleXStyles;
+  forwardRef?: RefObject<HTMLInputElement | null>;
 }
 
 export const formats: Record<TemporalUnit, string> = {
@@ -56,12 +57,13 @@ export const DateInput: React.FC<DateInputProps> = ({
   onBlur,
   isActive,
   customStyle,
+  forwardRef,
 }) => {
   const format = formats[units];
-  const [tempValue, setTempValue] = useState(moment(value).format(format));
+  const [tempValue, setTempValue] = useState(moment.utc(value).format(format));
 
   useEffect(() => {
-    setTempValue(moment(value).format(format));
+    setTempValue(moment.utc(value).format(format));
   }, [value, format]);
 
   return (
@@ -77,13 +79,14 @@ export const DateInput: React.FC<DateInputProps> = ({
         setTempValue(raw);
         const regex = regexps[units];
         if (raw.match(regex)) {
-          const m = moment(raw, format);
+          const m = moment.utc(raw, format);
           if (m.isValid()) {
             setValue(m.toDate());
           }
         }
       }}
       autoFocus={autoFocus}
+      ref={forwardRef}
     />
   );
 };

--- a/src/components/QueryPanel/DateLiteralEditor.tsx
+++ b/src/components/QueryPanel/DateLiteralEditor.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from 'react';
+import * as Malloy from '@malloydata/malloy-interfaces';
+import {useRef, useState} from 'react';
+import {DateInput, formats} from '../DateInput';
+import moment from 'moment';
+import {tokenStyles} from '../primitives/tokens/styles';
+import * as Popover from '@radix-ui/react-popover';
+import stylex, {StyleXStyles} from '@stylexjs/stylex';
+import {DatePicker} from '../primitives';
+import ErrorIcon from '../primitives/ErrorIcon';
+import {
+  LiteralValueWithDateLiteral,
+  LiteralValueWithTimestampLiteral,
+} from '@malloydata/malloy-interfaces';
+import {useClickOutside} from '../hooks/useClickOutside';
+
+interface DateLiteralEditorProps {
+  value: LiteralValueWithDateLiteral | LiteralValueWithTimestampLiteral;
+  setValue: (value: Malloy.LiteralValue) => void;
+  customStyle?: StyleXStyles;
+}
+
+export function DateLiteralEditor({
+  value,
+  setValue,
+  customStyle,
+}: DateLiteralEditorProps) {
+  const [errorMessage, setErrorMessage] = useState('');
+  const [open, setOpen] = useState(false);
+  const input = useRef<HTMLInputElement>(null);
+  const picker = useRef<HTMLDivElement>(null);
+
+  const isDate = value.kind === 'date_literal';
+  const date = isDate ? value.date_value : value.timestamp_value;
+  const units = isDate ? 'day' : 'second';
+
+  const onSetValue = (date: Date) => {
+    if (date) {
+      setErrorMessage('');
+      if (isDate) {
+        setValue({
+          kind: 'date_literal',
+          date_value: moment.utc(date).format(formats['day']),
+        });
+      } else {
+        setValue({
+          kind: 'timestamp_literal',
+          timestamp_value: moment.utc(date).format(formats['second']),
+        });
+      }
+    } else {
+      setErrorMessage('Invalid date');
+    }
+  };
+
+  useClickOutside([input, picker], () => {
+    setOpen(false);
+  });
+
+  return (
+    <Popover.Root open={open} onOpenChange={() => {}}>
+      <Popover.Trigger asChild>
+        <div {...stylex.props(tokenStyles.main, styles.wrapper, customStyle)}>
+          <DateInput
+            value={moment.utc(date).toDate()}
+            setValue={onSetValue}
+            units={units}
+            onFocus={() => setOpen(true)}
+            customStyle={{
+              ...styles.input,
+              ...(isDate ? styles.dateInput : styles.timestampInput),
+            }}
+            forwardRef={input}
+          />
+        </div>
+      </Popover.Trigger>
+      {errorMessage && <ErrorIcon errorMessage={errorMessage} />}
+      <Popover.Portal>
+        <Popover.Content align="center" asChild>
+          <DatePicker
+            value={moment.utc(date).toDate()}
+            setValue={onSetValue}
+            units={units}
+            maxLevel={units}
+            customStyle={styles.datePicker}
+            forwardRef={picker}
+          />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+const styles = stylex.create({
+  input: {
+    border: 'none',
+    height: 26,
+    backgroundColor: {
+      default: 'transparent',
+      ':focus': 'white',
+    },
+  },
+  dateInput: {
+    width: '5.5em',
+  },
+  timestampInput: {
+    width: '10em',
+  },
+  wrapper: {},
+  datePicker: {
+    display: 'flex',
+    flexDirection: 'column',
+    boxShadow:
+      '0 1px 2px 0 rgba(0, 0, 0, 0.1), 0 2px 12px 0 rgba(0, 0, 0, 0.1)',
+    backgroundColor: 'white',
+    borderRadius: 8,
+    width: 260,
+  },
+});

--- a/src/components/QueryPanel/LiteralValueEditor.tsx
+++ b/src/components/QueryPanel/LiteralValueEditor.tsx
@@ -7,14 +7,13 @@
 
 import * as React from 'react';
 import * as Malloy from '@malloydata/malloy-interfaces';
-import {RawLiteralValue} from '@malloydata/malloy-query-builder';
 import {EditableToken, SelectorToken, Token} from '../primitives';
-import stylex, {StyleXStyles} from '@stylexjs/stylex';
-import ErrorIcon from '../primitives/ErrorIcon';
+import {StyleXStyles} from '@stylexjs/stylex';
+import {DateLiteralEditor} from './DateLiteralEditor';
 
 export interface LiteralValueEditorProps {
   value: Malloy.LiteralValue | undefined;
-  setValue: (value: RawLiteralValue) => void;
+  setValue: (value: Malloy.LiteralValue) => void;
   customStyle?: StyleXStyles;
 }
 
@@ -23,7 +22,6 @@ export function LiteralValueEditor({
   setValue,
   customStyle,
 }: LiteralValueEditorProps) {
-  const [errorMessage, setErrorMessage] = React.useState('');
   if (!value) {
     return null;
   }
@@ -37,30 +35,20 @@ export function LiteralValueEditor({
             {label: 'true', value: 'true'},
             {label: 'false', value: 'false'},
           ]}
-          onChange={value => setValue(value === 'true')}
+          onChange={value =>
+            setValue({kind: 'boolean_literal', boolean_value: value === 'true'})
+          }
           customStyle={customStyle}
         />
       );
     case 'date_literal':
+    case 'timestamp_literal':
       return (
-        <div {...stylex.props(styles.row)}>
-          <input
-            value={value.date_value.split(' ')[0]}
-            type="date"
-            onChange={event => {
-              if (event.target.valueAsDate) {
-                setErrorMessage('');
-                setValue({
-                  date: event.target.valueAsDate,
-                  granularity: 'day',
-                });
-              } else {
-                setErrorMessage('Invalid date');
-              }
-            }}
-          />
-          {errorMessage && <ErrorIcon errorMessage={errorMessage} />}
-        </div>
+        <DateLiteralEditor
+          value={value}
+          setValue={setValue}
+          customStyle={customStyle}
+        />
       );
     case 'null_literal':
       return <Token label="∅" />;
@@ -69,7 +57,9 @@ export function LiteralValueEditor({
         <EditableToken
           value={value.number_value}
           type="number"
-          onChange={value => setValue(value)}
+          onChange={value =>
+            setValue({kind: 'number_literal', number_value: value})
+          }
           customStyle={customStyle}
         />
       );
@@ -77,44 +67,24 @@ export function LiteralValueEditor({
       return (
         <EditableToken
           value={value.string_value}
-          onChange={value => setValue(value)}
+          onChange={value =>
+            setValue({kind: 'string_literal', string_value: value})
+          }
           customStyle={customStyle}
         />
-      );
-    case 'timestamp_literal':
-      return (
-        <div {...stylex.props(styles.row)}>
-          <input
-            value={value.timestamp_value}
-            type="date"
-            onChange={event => {
-              if (event.target.valueAsDate) {
-                setErrorMessage('');
-                setValue({
-                  date: event.target.valueAsDate,
-                  granularity: 'second',
-                });
-              } else {
-                setErrorMessage('Invalid date');
-              }
-            }}
-          />
-          {errorMessage && <ErrorIcon errorMessage={errorMessage} />}
-        </div>
       );
     case 'filter_expression_literal':
       return (
         <EditableToken
           value={value.filter_expression_value}
-          onChange={value => setValue(value)}
+          onChange={value =>
+            setValue({
+              kind: 'filter_expression_literal',
+              filter_expression_value: value,
+            })
+          }
           customStyle={customStyle}
         />
       );
   }
 }
-
-const styles = stylex.create({
-  row: {
-    display: 'flex',
-  },
-});

--- a/src/components/filters/DateTimeFilterCore.tsx
+++ b/src/components/filters/DateTimeFilterCore.tsx
@@ -449,13 +449,13 @@ function createTemporalLiteral(
 ): TemporalLiteral {
   return {
     moment: 'literal',
-    literal: moment(date).format(formats[units]),
+    literal: moment.utc(date).format(formats[units]),
   };
 }
 
 function extractDateFromMoment(momentObj?: Moment): Date {
   if (momentObj && momentObj.moment === 'literal') {
-    return moment(momentObj.literal).toDate();
+    return moment.utc(momentObj.literal).toDate();
   }
 
   // For other moment types, default to now

--- a/src/components/primitives/DatePicker.tsx
+++ b/src/components/primitives/DatePicker.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useEffect, useState} from 'react';
+import React, {RefObject, useEffect, useState} from 'react';
 import moment from 'moment';
 import stylex, {StyleXStyles} from '@stylexjs/stylex';
 import {TemporalUnit} from '@malloydata/malloy-filter';
@@ -20,6 +20,7 @@ interface DatePickerProps {
   units: TemporalUnit;
   maxLevel: TemporalUnit;
   customStyle?: StyleXStyles;
+  forwardRef?: RefObject<HTMLDivElement | null>;
 }
 
 function monthName(month: number) {
@@ -45,20 +46,21 @@ export default function DatePicker({
   units,
   maxLevel,
   customStyle,
+  forwardRef,
 }: DatePickerProps) {
   const [date, setDate] = useState(value);
   const calendar = getCalendar(date);
   const [pickLevel, setPickLevel] = useState<
     'day' | 'month' | 'year' | 'quarter' | 'week' | 'hour' | 'minute' | 'second'
   >(units);
-  const yearBucket = Math.floor(moment(date).year() / 10) * 10;
+  const yearBucket = Math.floor(moment.utc(date).year() / 10) * 10;
 
   useEffect(() => {
     setDate(value);
   }, [value]);
 
   const setYear = (year: number) => {
-    const newDate = moment(date).year(year).toDate();
+    const newDate = moment.utc(date).year(year).toDate();
     setDate(newDate);
     setValue(newDate);
   };
@@ -80,7 +82,7 @@ export default function DatePicker({
         onClick={click}
         {...stylex.props(
           styles.year,
-          moment(date).year() === yearBucket + offset && styles.yearSelected
+          moment.utc(date).year() === yearBucket + offset && styles.yearSelected
         )}
       >
         {yearBucket + offset}
@@ -89,7 +91,7 @@ export default function DatePicker({
   };
 
   const setMonth = (month: number) => {
-    const newDate = moment(date).month(month).toDate();
+    const newDate = moment.utc(date).month(month).toDate();
     setDate(newDate);
     setValue(newDate);
   };
@@ -105,7 +107,8 @@ export default function DatePicker({
   };
 
   const setQuarter = (quarter: number) => {
-    const newDate = moment(date)
+    const newDate = moment
+      .utc(date)
       .quarter(quarter + 1)
       .toDate();
     setDate(newDate);
@@ -115,8 +118,8 @@ export default function DatePicker({
   const monthButton = (month: number) => {
     const click = () => setMonth(month);
     const isSelected =
-      moment(date).month() === month &&
-      moment(date).year() === moment(value).year();
+      moment.utc(date).month() === month &&
+      moment.utc(date).year() === moment.utc(value).year();
     return (
       <div
         onClick={click}
@@ -130,8 +133,8 @@ export default function DatePicker({
   const quarterButton = (quarter: number) => {
     const click = () => setQuarter(quarter);
     const isSelected =
-      moment(date).quarter() - 1 === quarter &&
-      moment(date).year() === moment(value).year();
+      moment.utc(date).quarter() - 1 === quarter &&
+      moment.utc(date).year() === moment.utc(value).year();
     return (
       <div
         onClick={click}
@@ -143,7 +146,7 @@ export default function DatePicker({
   };
 
   return (
-    <div {...stylex.props(styles.outer, customStyle)}>
+    <div {...stylex.props(styles.outer, customStyle)} ref={forwardRef}>
       <div {...stylex.props(styles.controlRow)}>
         <div {...stylex.props(styles.arrowButton)}>
           <Button
@@ -152,13 +155,13 @@ export default function DatePicker({
             icon="chevronLeft"
             onClick={() => {
               if (pickLevel === 'day' || pickLevel === 'week') {
-                setDate(moment(date).subtract(1, 'month').toDate());
+                setDate(moment.utc(date).subtract(1, 'month').toDate());
               } else if (pickLevel === 'month' || pickLevel === 'quarter') {
-                setDate(moment(date).subtract(1, 'year').toDate());
+                setDate(moment.utc(date).subtract(1, 'year').toDate());
               } else if (pickLevel === 'year') {
-                setDate(moment(date).subtract(10, 'years').toDate());
+                setDate(moment.utc(date).subtract(10, 'years').toDate());
               } else {
-                setDay(moment(date).subtract(1, 'days').toDate());
+                setDay(moment.utc(date).subtract(1, 'days').toDate());
               }
             }}
           />
@@ -182,9 +185,9 @@ export default function DatePicker({
           }}
         >
           {(pickLevel === 'day' || pickLevel === 'week') &&
-            moment(date).format('MMMM YYYY')}
+            moment.utc(date).format('MMMM YYYY')}
           {(pickLevel === 'month' || pickLevel === 'quarter') &&
-            moment(date).format('YYYY')}
+            moment.utc(date).format('YYYY')}
           {pickLevel === 'year' && (
             <>
               {yearBucket}-{yearBucket + 9}
@@ -193,7 +196,7 @@ export default function DatePicker({
           {(pickLevel === 'hour' ||
             pickLevel === 'minute' ||
             pickLevel === 'second') && (
-            <>{moment(date).format('MMMM D, YYYY')}</>
+            <>{moment.utc(date).format('MMMM D, YYYY')}</>
           )}
         </div>
         <div {...stylex.props(styles.arrowButton)}>
@@ -203,13 +206,13 @@ export default function DatePicker({
             icon="chevronRight"
             onClick={() => {
               if (pickLevel === 'day' || pickLevel === 'week') {
-                setDate(moment(date).add(1, 'month').toDate());
+                setDate(moment.utc(date).add(1, 'month').toDate());
               } else if (pickLevel === 'month' || pickLevel === 'quarter') {
-                setDate(moment(date).add(1, 'year').toDate());
+                setDate(moment.utc(date).add(1, 'year').toDate());
               } else if (pickLevel === 'year') {
-                setDate(moment(date).add(10, 'years').toDate());
+                setDate(moment.utc(date).add(10, 'years').toDate());
               } else {
-                setDay(moment(date).add(1, 'days').toDate());
+                setDay(moment.utc(date).add(1, 'days').toDate());
               }
             }}
           />
@@ -354,22 +357,22 @@ export default function DatePicker({
           <div {...stylex.props(styles.timePickerInner)}>
             <NumberInput
               label="Hours"
-              value={parseInt(moment(date).format('hh'))}
+              value={parseInt(moment.utc(date).format('hh'))}
               setValue={hour12 => {
-                const amPm = moment(date).hour() >= 12 ? 'PM' : 'AM';
+                const amPm = moment.utc(date).hour() >= 12 ? 'PM' : 'AM';
                 const newHour24 = parseInt(
-                  moment(`${hour12} ${amPm}`, ['hh A']).format('H')
+                  moment.utc(`${hour12} ${amPm}`, ['hh A']).format('H')
                 );
-                setValue(moment(date).hour(newHour24).toDate());
+                setValue(moment.utc(date).hour(newHour24).toDate());
               }}
               width="40px"
             />
             {(units === 'minute' || units === 'second') && (
               <NumberInput
                 label="Minutes"
-                value={moment(date).minutes()}
+                value={moment.utc(date).minutes()}
                 setValue={minute => {
-                  setValue(moment(date).minute(minute).toDate());
+                  setValue(moment.utc(date).minute(minute).toDate());
                 }}
                 width="40px"
               />
@@ -377,9 +380,9 @@ export default function DatePicker({
             {units === 'second' && (
               <NumberInput
                 label="Seconds"
-                value={moment(date).seconds()}
+                value={moment.utc(date).seconds()}
                 setValue={second => {
-                  setValue(moment(date).second(second).toDate());
+                  setValue(moment.utc(date).second(second).toDate());
                 }}
                 width="40px"
               />
@@ -392,13 +395,13 @@ export default function DatePicker({
               }}
             >
               <SelectDropdown
-                value={moment(date).hour() >= 12 ? 'PM' : 'AM'}
+                value={moment.utc(date).hour() >= 12 ? 'PM' : 'AM'}
                 onChange={(amPm: 'AM' | 'PM') => {
-                  const hour12 = parseInt(moment(date).format('h'));
+                  const hour12 = parseInt(moment.utc(date).format('h'));
                   const newHour24 = parseInt(
-                    moment(`${hour12} ${amPm}`, ['hh A']).format('H')
+                    moment.utc(`${hour12} ${amPm}`, ['hh A']).format('H')
                   );
-                  setValue(moment(date).hour(newHour24).toDate());
+                  setValue(moment.utc(date).hour(newHour24).toDate());
                 }}
                 options={[
                   {value: 'AM', label: 'AM'},
@@ -660,7 +663,7 @@ const styles = stylex.create({
 });
 
 function getCalendar(date: Date) {
-  const firstDayOfMonth = moment(date).date(1);
+  const firstDayOfMonth = moment.utc(date).date(1);
   const dow = firstDayOfMonth.day();
   const daysInMonth = firstDayOfMonth.daysInMonth();
   const daysInPreviousMonth = firstDayOfMonth


### PR DESCRIPTION
The native date picker was pretty disappointing to use, and didn't match our styling, use our own. Also switch from `moment()` to `moment.utc()` so our date stamps actually match. This is a going to require a change to our malloy generation code to correctly, since `timestamp_value: '1980-05-18 15:00:00',` produces `@1980-05-19 03:00:00` I might try to land that fix before landing this.