### PR TITLE
Fix Source Panel order_by. Add disabled messages.

### DIFF
--- a/src/components/QueryPanel/AddMenu/AddOrderBy.tsx
+++ b/src/components/QueryPanel/AddMenu/AddOrderBy.tsx
@@ -35,7 +35,9 @@ export function AddOrderBy({rootQuery, view, search}: AddEmptyNestProps) {
         .filter(field => field.kind === 'dimension')
         .filter(field => ORDERABLE_TYPES.includes(field.type.kind))
         .filter(field => {
-          // In this context, field.name is actually the full name of the field
+          // In this context, field.name is actually the full name of the field, and
+          // the segment fields also include the qualified name, therefore we can
+          // provide an empty path value.
           return segment ? !segmentHasOrderBy(segment, [], field.name) : true;
         }),
     [outputSchemaFields, segment]

--- a/src/components/QueryPanel/AddMenu/AddOrderBy.tsx
+++ b/src/components/QueryPanel/AddMenu/AddOrderBy.tsx
@@ -34,9 +34,10 @@ export function AddOrderBy({rootQuery, view, search}: AddEmptyNestProps) {
       outputSchemaFields
         .filter(field => field.kind === 'dimension')
         .filter(field => ORDERABLE_TYPES.includes(field.type.kind))
-        .filter(field =>
-          segment ? !segmentHasOrderBy(segment, field.name) : true
-        ),
+        .filter(field => {
+          // In this context, field.name is actually the full name of the field
+          return segment ? !segmentHasOrderBy(segment, [], field.name) : true;
+        }),
     [outputSchemaFields, segment]
   );
 

--- a/src/components/QueryPanel/AddMenu/AddOrderBy.tsx
+++ b/src/components/QueryPanel/AddMenu/AddOrderBy.tsx
@@ -34,12 +34,9 @@ export function AddOrderBy({rootQuery, view, search}: AddEmptyNestProps) {
       outputSchemaFields
         .filter(field => field.kind === 'dimension')
         .filter(field => ORDERABLE_TYPES.includes(field.type.kind))
-        .filter(field => {
-          // In this context, field.name is actually the full name of the field, and
-          // the segment fields also include the qualified name, therefore we can
-          // provide an empty path value.
-          return segment ? !segmentHasOrderBy(segment, field.name) : true;
-        }),
+        .filter(field =>
+          segment ? !segmentHasOrderBy(segment, field.name) : true
+        ),
     [outputSchemaFields, segment]
   );
 

--- a/src/components/QueryPanel/AddMenu/AddOrderBy.tsx
+++ b/src/components/QueryPanel/AddMenu/AddOrderBy.tsx
@@ -38,7 +38,7 @@ export function AddOrderBy({rootQuery, view, search}: AddEmptyNestProps) {
           // In this context, field.name is actually the full name of the field, and
           // the segment fields also include the qualified name, therefore we can
           // provide an empty path value.
-          return segment ? !segmentHasOrderBy(segment, [], field.name) : true;
+          return segment ? !segmentHasOrderBy(segment, field.name) : true;
         }),
     [outputSchemaFields, segment]
   );

--- a/src/components/SourcePanel/FieldTokenWithActions.tsx
+++ b/src/components/SourcePanel/FieldTokenWithActions.tsx
@@ -13,7 +13,7 @@ import {
   addFilter,
   addGroupBy,
   addNest,
-  addOrderBy,
+  addOrderByFromSource,
 } from '../utils/segment';
 import {useOperations} from './hooks/useOperations';
 import {FilterPopover} from '../filters/FilterPopover';
@@ -71,7 +71,7 @@ export function FieldTokenWithActions({
       } else if (operation === 'aggregate' && isAggregateAllowed) {
         addAggregate(view, field, path);
       } else if (operation === 'orderBy' && isOrderByAllowed) {
-        addOrderBy(view, field);
+        addOrderByFromSource(view, path, field.name);
       } else if (operation === 'filter' && isFilterAllowed && filter) {
         addFilter(view, field, path, filter);
       }

--- a/src/components/SourcePanel/FieldTokenWithActions.tsx
+++ b/src/components/SourcePanel/FieldTokenWithActions.tsx
@@ -45,13 +45,9 @@ export function FieldTokenWithActions({
   const view = currentNestView ?? viewDef;
 
   const {
-    isGroupByAllowed,
     groupByDisabledReason,
-    isAggregateAllowed,
     aggregateDisabledReason,
-    isFilterAllowed,
     filterDisabledReason,
-    isOrderByAllowed,
     orderByDisabledReason,
   } = useOperations(view, field, path);
 
@@ -66,13 +62,13 @@ export function FieldTokenWithActions({
     filter?: ParsedFilter
   ) => {
     if (field.kind === 'dimension' || field.kind === 'measure') {
-      if (operation === 'groupBy' && isGroupByAllowed) {
+      if (operation === 'groupBy' && !groupByDisabledReason) {
         addGroupBy(view, field, path);
-      } else if (operation === 'aggregate' && isAggregateAllowed) {
+      } else if (operation === 'aggregate' && !aggregateDisabledReason) {
         addAggregate(view, field, path);
-      } else if (operation === 'orderBy' && isOrderByAllowed) {
+      } else if (operation === 'orderBy' && !orderByDisabledReason) {
         addOrderByFromSource(view, path, field.name);
-      } else if (operation === 'filter' && isFilterAllowed && filter) {
+      } else if (operation === 'filter' && !filterDisabledReason && filter) {
         addFilter(view, field, path, filter);
       }
       setQuery?.(rootQuery?.build());
@@ -123,7 +119,7 @@ export function FieldTokenWithActions({
             <ActionButton
               icon="aggregate"
               tooltip={aggregateDisabledReason || 'Add as aggregate'}
-              disabled={!isAggregateAllowed}
+              disabled={!!aggregateDisabledReason}
               onClick={() => handleAddOperationAction('aggregate')}
               onTooltipOpenChange={setIsTooltipOpen}
             />
@@ -135,7 +131,7 @@ export function FieldTokenWithActions({
                 <ActionButton
                   icon="filter"
                   tooltip={filterDisabledReason || 'Add as filter'}
-                  disabled={!isFilterAllowed}
+                  disabled={!!filterDisabledReason}
                   onTooltipOpenChange={setIsTooltipOpen}
                 />
               }
@@ -144,7 +140,7 @@ export function FieldTokenWithActions({
             <ActionButton
               icon="orderBy"
               tooltip={orderByDisabledReason || 'Add as order by'}
-              disabled={!isOrderByAllowed}
+              disabled={!!orderByDisabledReason}
               onClick={() => handleAddOperationAction('orderBy')}
               onTooltipOpenChange={setIsTooltipOpen}
             />
@@ -154,7 +150,7 @@ export function FieldTokenWithActions({
             <ActionButton
               icon="groupBy"
               tooltip={groupByDisabledReason || 'Add as group by'}
-              disabled={!isGroupByAllowed}
+              disabled={!!groupByDisabledReason}
               onClick={() => handleAddOperationAction('groupBy')}
               onTooltipOpenChange={setIsTooltipOpen}
             />
@@ -166,7 +162,7 @@ export function FieldTokenWithActions({
                 <ActionButton
                   icon="filter"
                   tooltip={filterDisabledReason || 'Add as filter'}
-                  disabled={!isFilterAllowed}
+                  disabled={!!filterDisabledReason}
                   onTooltipOpenChange={setIsTooltipOpen}
                 />
               }
@@ -175,7 +171,7 @@ export function FieldTokenWithActions({
             <ActionButton
               icon="orderBy"
               tooltip={orderByDisabledReason || 'Add as order by'}
-              disabled={!isOrderByAllowed}
+              disabled={!!orderByDisabledReason}
               onClick={() => handleAddOperationAction('orderBy')}
               onTooltipOpenChange={setIsTooltipOpen}
             />
@@ -183,9 +179,9 @@ export function FieldTokenWithActions({
         ) : null
       }
       onClick={
-        field.kind === 'dimension' && isGroupByAllowed
+        field.kind === 'dimension' && !groupByDisabledReason
           ? () => handleAddOperationAction('groupBy')
-          : field.kind === 'measure' && isAggregateAllowed
+          : field.kind === 'measure' && !aggregateDisabledReason
             ? () => handleAddOperationAction('aggregate')
             : field.kind === 'view'
               ? () => handleAddView()

--- a/src/components/SourcePanel/FieldTokenWithActions.tsx
+++ b/src/components/SourcePanel/FieldTokenWithActions.tsx
@@ -46,9 +46,13 @@ export function FieldTokenWithActions({
 
   const {
     isGroupByAllowed,
+    groupByDisabledReason,
     isAggregateAllowed,
+    aggregateDisabledReason,
     isFilterAllowed,
+    filterDisabledReason,
     isOrderByAllowed,
+    orderByDisabledReason,
   } = useOperations(view, field, path);
 
   const [isFilterPopoverOpen, setIsFilterPopoverOpen] = useState<
@@ -99,7 +103,11 @@ export function FieldTokenWithActions({
               icon="insert"
               disabled={!rootQuery?.isEmpty()}
               onClick={handleSetView}
-              tooltip="Add view"
+              tooltip={
+                !rootQuery?.isEmpty()
+                  ? 'Can only add a view to an empty query.'
+                  : 'Add view'
+              }
               onTooltipOpenChange={setIsTooltipOpen}
             />
 
@@ -114,7 +122,7 @@ export function FieldTokenWithActions({
           <>
             <ActionButton
               icon="aggregate"
-              tooltip="Add as aggregate"
+              tooltip={aggregateDisabledReason || 'Add as aggregate'}
               disabled={!isAggregateAllowed}
               onClick={() => handleAddOperationAction('aggregate')}
               onTooltipOpenChange={setIsTooltipOpen}
@@ -126,7 +134,7 @@ export function FieldTokenWithActions({
               trigger={
                 <ActionButton
                   icon="filter"
-                  tooltip="Add as filter"
+                  tooltip={filterDisabledReason || 'Add as filter'}
                   disabled={!isFilterAllowed}
                   onTooltipOpenChange={setIsTooltipOpen}
                 />
@@ -135,7 +143,7 @@ export function FieldTokenWithActions({
             />
             <ActionButton
               icon="orderBy"
-              tooltip="Add as order by"
+              tooltip={orderByDisabledReason || 'Add as order by'}
               disabled={!isOrderByAllowed}
               onClick={() => handleAddOperationAction('orderBy')}
               onTooltipOpenChange={setIsTooltipOpen}
@@ -145,7 +153,7 @@ export function FieldTokenWithActions({
           <>
             <ActionButton
               icon="groupBy"
-              tooltip="Add as group by"
+              tooltip={groupByDisabledReason || 'Add as group by'}
               disabled={!isGroupByAllowed}
               onClick={() => handleAddOperationAction('groupBy')}
               onTooltipOpenChange={setIsTooltipOpen}
@@ -157,7 +165,7 @@ export function FieldTokenWithActions({
               trigger={
                 <ActionButton
                   icon="filter"
-                  tooltip="Add as filter"
+                  tooltip={filterDisabledReason || 'Add as filter'}
                   disabled={!isFilterAllowed}
                   onTooltipOpenChange={setIsTooltipOpen}
                 />
@@ -166,7 +174,7 @@ export function FieldTokenWithActions({
             />
             <ActionButton
               icon="orderBy"
-              tooltip="Add as order by"
+              tooltip={orderByDisabledReason || 'Add as order by'}
               disabled={!isOrderByAllowed}
               onClick={() => handleAddOperationAction('orderBy')}
               onTooltipOpenChange={setIsTooltipOpen}

--- a/src/components/SourcePanel/hooks/useOperations.ts
+++ b/src/components/SourcePanel/hooks/useOperations.ts
@@ -18,10 +18,6 @@ import {
   isNotAnnotatedFilteredField,
   ViewParent,
 } from '../../utils/fields';
-import {
-  ASTArrowQueryDefinition,
-  ASTSegmentViewDefinition,
-} from '@malloydata/malloy-query-builder';
 
 function toFullName(path: string[] | undefined, name: string): string {
   return [...(path || []), name].join('.');
@@ -33,9 +29,6 @@ export function useOperations(
   path: string[]
 ) {
   const fullName = toFullName(path, field.name);
-  // So if `path` exists, then we need to walk up the path
-  // when computing anything.
-
   const flattenedFields = useMemo(() => {
     const {fields} = getInputSchemaFromViewParent(view);
     const inputPath = path.join('.');
@@ -82,7 +75,7 @@ export function useOperations(
 
   const filterDisabledReason = useMemo(() => {
     if (!matchingFieldItem) {
-      return `Unexpected Error: Could not find a field ${fullName}`;
+      return `Unexpected Error: Could not find a field ${fullName}.`;
     }
     if (!['dimension', 'measure'].includes(matchingFieldItem.field.kind)) {
       return `Filtering is only available for a dimension or measure.`;
@@ -100,7 +93,7 @@ export function useOperations(
 
   const orderByDisabledReason = useMemo(() => {
     if (!matchingFieldItem) {
-      return `Unexpected Error: Could not find a field ${fullName}`;
+      return `Unexpected Error: Could not find a field ${fullName}.`;
     }
     const segment = getSegmentIfPresent(view);
     if (segment && segmentHasOrderBy(segment, path, field.name)) {
@@ -130,7 +123,7 @@ export function useOperations(
     }
 
     return '';
-  }, [matchingFieldItem, view, field.name, fullName]);
+  }, [matchingFieldItem, view, path, field.name, fullName]);
 
   return {
     isGroupByAllowed: !groupByDisabledReason,

--- a/src/components/SourcePanel/hooks/useOperations.ts
+++ b/src/components/SourcePanel/hooks/useOperations.ts
@@ -99,20 +99,11 @@ export function useOperations(
     if (segment && segmentHasOrderBy(segment, path, field.name)) {
       return 'Query is already ordered by this field.';
     }
-    const outputSchemaFields = view.getOutputSchema().fields;
-
     if (!segment || !segmentHasFieldInOutputSpace(segment, path, field.name)) {
       return 'Order by is only available for fields in the output.';
     }
-    if (
-      !outputSchemaFields.some(
-        fieldInfo => matchingFieldItem.field.name === fieldInfo.name
-      )
-    ) {
-      return 'Order By is only available for fields already in the output.';
-    }
-    if (matchingFieldItem.field.kind !== 'dimension') {
-      return 'Order By is only available for dimension fields.';
+    if (!['dimension', 'measure'].includes(matchingFieldItem.field.kind)) {
+      return 'Order By is only available for dimension or measure fields.';
     }
     if (
       !ORDERABLE_TYPES.includes(

--- a/src/components/SourcePanel/hooks/useOperations.ts
+++ b/src/components/SourcePanel/hooks/useOperations.ts
@@ -11,17 +11,14 @@ import {flattenFieldsTree} from '../utils';
 import {
   getSegmentIfPresent,
   segmentHasFieldInOutputSpace,
-  segmentHasOrderBy,
+  segmentHasOrderBySourceField,
+  toFullName,
 } from '../../utils/segment';
 import {
   getInputSchemaFromViewParent,
   isNotAnnotatedFilteredField,
   ViewParent,
 } from '../../utils/fields';
-
-function toFullName(path: string[] | undefined, name: string): string {
-  return [...(path || []), name].join('.');
-}
 
 export function useOperations(
   view: ViewParent,
@@ -96,7 +93,7 @@ export function useOperations(
       return `Unexpected Error: Could not find a field ${fullName}.`;
     }
     const segment = getSegmentIfPresent(view);
-    if (segment && segmentHasOrderBy(segment, path, field.name)) {
+    if (segment && segmentHasOrderBySourceField(segment, path, field.name)) {
       return 'Query is already ordered by this field.';
     }
     if (!segment || !segmentHasFieldInOutputSpace(segment, path, field.name)) {

--- a/src/components/utils/fields.ts
+++ b/src/components/utils/fields.ts
@@ -67,6 +67,9 @@ export function getViewDefinition(parent: ViewParent) {
 export function getInputSchemaFromViewParent(
   parent: ViewParent
 ): Malloy.Schema {
+  if (!parent) {
+    return {fields: []};
+  }
   const definition = getViewDefinition(parent);
   return definition.getInputSchema();
 }

--- a/src/components/utils/segment.spec.ts
+++ b/src/components/utils/segment.spec.ts
@@ -16,6 +16,7 @@ import {
   getSegmentIfPresent,
   segmentHasLimit,
   segmentHasOrderBy,
+  segmentHasOrderBySourceField,
   segmentNestNo,
 } from './segment';
 import {modelInfo} from '../../test/model';
@@ -67,37 +68,44 @@ describe('segment utils', () => {
   describe('segmentHasOrderBy', () => {
     it('is false when there are no order_bys', () => {
       const segment = query.getOrAddDefaultSegment();
-      expect(segmentHasOrderBy(segment, [], 'measure_a')).toBe(false);
+      expect(segmentHasOrderBy(segment, 'measure_a')).toBe(false);
     });
 
     it('is false when there is no order_by with a given name', () => {
       const segment = query.getOrAddDefaultSegment();
       segment.addGroupBy('string_dimension');
       segment.addOrderBy('string_dimension');
-      expect(segmentHasOrderBy(segment, [], 'measure_a')).toBe(false);
+      expect(segmentHasOrderBy(segment, 'measure_a')).toBe(false);
     });
 
     it('is true when there is an order_by measure with a given name', () => {
       const segment = query.getOrAddDefaultSegment();
       segment.addAggregate('measure_a');
       segment.addOrderBy('measure_a');
-      expect(segmentHasOrderBy(segment, [], 'measure_a')).toBe(true);
+      expect(segmentHasOrderBy(segment, 'measure_a')).toBe(true);
     });
 
     it('is true when there is an order_by dimension with a given name', () => {
       const segment = query.getOrAddDefaultSegment();
       segment.addGroupBy('string_dimension');
       segment.addOrderBy('string_dimension');
-      expect(segmentHasOrderBy(segment, [], 'string_dimension')).toBe(true);
+      expect(segmentHasOrderBy(segment, 'string_dimension')).toBe(true);
     });
+  });
 
-    it('is false if the parameters have a path but the segment does not', () => {
+  describe('segmentHasOrderBySourceField', () => {
+    it('resolves items when the source field has a path', () => {
       const segment = query.getOrAddDefaultSegment();
       segment.addGroupBy('string_dimension');
-      segment.addOrderBy('string_dimension');
-      expect(segmentHasOrderBy(segment, ['root'], 'string_dimension')).toBe(
-        false
+      segment.addGroupBy(
+        'string_dimension',
+        ['join_a'],
+        'join_a string_dimension'
       );
+      segment.addOrderBy('join_a string_dimension');
+      expect(
+        segmentHasOrderBySourceField(segment, ['join_a'], 'string_dimension')
+      ).toBe(true);
     });
   });
 

--- a/src/components/utils/segment.spec.ts
+++ b/src/components/utils/segment.spec.ts
@@ -67,28 +67,37 @@ describe('segment utils', () => {
   describe('segmentHasOrderBy', () => {
     it('is false when there are no order_bys', () => {
       const segment = query.getOrAddDefaultSegment();
-      expect(segmentHasOrderBy(segment, 'measure_a')).toBe(false);
+      expect(segmentHasOrderBy(segment, [], 'measure_a')).toBe(false);
     });
 
     it('is false when there is no order_by with a given name', () => {
       const segment = query.getOrAddDefaultSegment();
       segment.addGroupBy('string_dimension');
       segment.addOrderBy('string_dimension');
-      expect(segmentHasOrderBy(segment, 'measure_a')).toBe(false);
+      expect(segmentHasOrderBy(segment, [], 'measure_a')).toBe(false);
     });
 
     it('is true when there is an order_by measure with a given name', () => {
       const segment = query.getOrAddDefaultSegment();
       segment.addAggregate('measure_a');
       segment.addOrderBy('measure_a');
-      expect(segmentHasOrderBy(segment, 'measure_a')).toBe(true);
+      expect(segmentHasOrderBy(segment, [], 'measure_a')).toBe(true);
     });
 
     it('is true when there is an order_by dimension with a given name', () => {
       const segment = query.getOrAddDefaultSegment();
       segment.addGroupBy('string_dimension');
       segment.addOrderBy('string_dimension');
-      expect(segmentHasOrderBy(segment, 'string_dimension')).toBe(true);
+      expect(segmentHasOrderBy(segment, [], 'string_dimension')).toBe(true);
+    });
+
+    it('is false if the parameters have a path but the segment does not', () => {
+      const segment = query.getOrAddDefaultSegment();
+      segment.addGroupBy('string_dimension');
+      segment.addOrderBy('string_dimension');
+      expect(segmentHasOrderBy(segment, ['root'], 'string_dimension')).toBe(
+        false
+      );
     });
   });
 

--- a/src/components/utils/segment.ts
+++ b/src/components/utils/segment.ts
@@ -72,7 +72,16 @@ export function segmentHasFieldInOutputSpace(
         return isEqual;
       }
     } else if (operation instanceof ASTAggregateViewOperation) {
-      debugger;
+      if (operation.field.node.expression.kind === 'field_reference') {
+        const isEqual = areReferencesEqual(
+          path,
+          name,
+          operation.field.node.expression.path,
+          operation.field.node.expression.name
+        );
+
+        return isEqual;
+      }
     }
     return false;
   });

--- a/src/test/model.ts
+++ b/src/test/model.ts
@@ -50,6 +50,25 @@ export const modelInfo: Malloy.ModelInfo = {
             kind: 'dimension',
             type: {kind: 'timestamp_type'},
           },
+          {
+            name: 'join_a',
+            kind: 'join',
+            relationship: 'one',
+            schema: {
+              fields: [
+                {
+                  name: 'string_dimension',
+                  kind: 'dimension',
+                  type: {kind: 'string_type'},
+                },
+                {
+                  name: 'measure_a',
+                  kind: 'measure',
+                  type: {kind: 'number_type'},
+                },
+              ],
+            },
+          },
         ],
       },
     },


### PR DESCRIPTION
Updates the Source Panel to include a "disabled reason" whenever the action button is disabled.

<img width="653" alt="image" src="https://github.com/user-attachments/assets/a69c6735-0879-4e42-a73f-f4c4668c81a3" />

<img width="649" alt="image" src="https://github.com/user-attachments/assets/d4070b2b-0304-4586-a0cb-e399f4c77a6e" />


This also fixes a long tail of issues related to the use of Order By when there are duplicate field names (but different field paths):


Fixes broken behavior around Order By which became especially obvious whenever a joined-in table has the same field name as another field.

https://github.com/user-attachments/assets/b9304501-ae70-4b6c-b0bf-35a2b0d19426

