### PR TITLE
Better query conversion failure handling

### DIFF
--- a/dev/Query.tsx
+++ b/dev/Query.tsx
@@ -32,6 +32,7 @@ const App = () => {
 
   const onQueryChange = React.useCallback(
     (query: Malloy.Query | string | undefined) => {
+      setQuery(query);
       console.info('Pushing', query);
       window.history.pushState(
         query,

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -144,8 +144,13 @@ export default function CodeEditor({
               label="Use Query Editor"
               onClick={() => {
                 if (malloy && malloyToQuery && validStableQuery) {
-                  const {query} = malloyToQuery(value);
-                  setQuery(query);
+                  const {query, logs} = malloyToQuery(value);
+                  if (logs.length) {
+                    console.error(logs);
+                  }
+                  if (query) {
+                    setQuery(query);
+                  }
                 }
               }}
               disabled={!validStableQuery}


### PR DESCRIPTION
Don't update query if query parsing fails, report errors if there are any, although we shouldn't get here if there are errors.