### PR TITLE
Bump version to 0.0.337

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloydata/malloy-explorer",
-  "version": "0.0.331",
+  "version": "0.0.337",
   "description": "Malloy visual query builder",
   "main": "dist/cjs/index.cjs",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump version to 0.0.337 to match malloy packages

## Test plan
- [ ] Merge, then `npm publish` from main