### PR TITLE
Publish via npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -10,6 +10,9 @@ jobs:
     needs:
       - test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,6 +21,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
+      - name: Upgrade npm for trusted publishing (OIDC)
+        run: npm install -g npm@latest
       - name: npm install, build, and publish
         run: |
           npm ci --loglevel error
@@ -27,4 +32,3 @@ jobs:
           npm publish --access=public
         env:
           CI: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Migrates `prerelease.yaml` off the static `NPM_TOKEN` to GitHub Actions OIDC trusted publishing, matching `malloydata/malloy` and `malloydata/malloy-cli`:

- `id-token: write` (plus `contents: read`, since a job-level `permissions` block drops the unlisted defaults the checkout/submodules need)
- npm upgraded in-job to ≥11.5.1 (OIDC requirement)
- `NPM_TOKEN` removed

`@malloydata/malloy-explorer` is registered on npmjs.com with `malloydata/malloy-explorer` + `prerelease.yaml` as its trusted publisher. The package already has a `repository` field, so provenance is fine.

**Scope:** workflow-only — no dependency or version bump. `prerelease.yaml` is `workflow_dispatch`-only, so merging this publishes nothing; it arms the OIDC path for the next manual prerelease dispatch, which is where it's first exercised.